### PR TITLE
科目別ページから自作課題を追加する機能

### DIFF
--- a/css/addTaskButton.css
+++ b/css/addTaskButton.css
@@ -1,0 +1,24 @@
+.scombzUtilitiesAddTaskButton {
+  position: absolute;
+  display: flex;
+  left: 5px;
+  bottom: 5px;
+  cursor: pointer;
+  font-size: 24px;
+  color: #fff;
+  border-radius: 1000px;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  background-color: #fff0;
+  transition: background-color 0.3s;
+}
+
+.scombzUtilitiesAddTaskButton:hover {
+  background-color: #fff3;
+}
+
+.scombzUtilitiesAddTaskButton:active {
+  background-color: #fff6;
+}

--- a/src/contents/addOriginalTaskInCourse.tsx
+++ b/src/contents/addOriginalTaskInCourse.tsx
@@ -1,0 +1,79 @@
+import createCache from "@emotion/cache";
+import { CacheProvider } from "@emotion/react";
+import { ThemeProvider, Box } from "@mui/material";
+import type { PlasmoCSConfig } from "plasmo";
+import React, { useEffect, useState, useMemo } from "react";
+import ReactDOMServer from "react-dom/server";
+import { MdOutlineNoteAdd } from "react-icons/md";
+import { OriginalTaskModal } from "./components/originalTaskModal";
+import { getCourseTitle } from "./util/functions";
+import theme from "~/theme";
+import { defaultSaves, type Saves } from "~settings";
+
+export const config: PlasmoCSConfig = {
+  matches: ["https://scombz.shibaura-it.ac.jp/lms/course*"],
+  run_at: "document_end",
+};
+
+const jsxToHtml = (jsx: React.ReactElement): string => {
+  return ReactDOMServer.renderToStaticMarkup(jsx);
+};
+
+const insertAddTaskButton = async (openModal: () => void) => {
+  const currentData = (await chrome.storage.local.get(defaultSaves)) as Saves;
+  if (!currentData.settings.useTaskList) return;
+  const button = (
+    <>
+      <link href={chrome.runtime.getURL("css/addTaskButton.css")} rel="stylesheet" />
+      <div className="scombzUtilitiesAddTaskButton">
+        <MdOutlineNoteAdd />
+      </div>
+    </>
+  );
+  const buttonHtml = jsxToHtml(button);
+  const target = document.querySelector("#report > .block-title") as HTMLDivElement;
+  if (!target) return;
+  target.insertAdjacentHTML("beforeend", buttonHtml);
+  document.querySelector(".scombzUtilitiesAddTaskButton")?.addEventListener("click", () => {
+    openModal();
+  });
+};
+
+const styleElement = document.createElement("style");
+
+const styleCache = createCache({
+  key: "plasmo-mui-cache",
+  prepend: true,
+  container: styleElement,
+});
+
+export const getStyle = () => styleElement;
+
+const AddTask = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const course = useMemo(() => getCourseTitle(), []);
+  const courseURL = useMemo(() => window.location.href, []);
+
+  useEffect(() => {
+    insertAddTaskButton(() => setIsModalOpen(true));
+  }, []);
+
+  return (
+    <CacheProvider value={styleCache}>
+      <ThemeProvider theme={theme}>
+        <Box>
+          <OriginalTaskModal
+            isOpen={isModalOpen}
+            setIsOpen={setIsModalOpen}
+            onClose={() => {}}
+            course={course}
+            courseURL={courseURL}
+          />
+        </Box>
+      </ThemeProvider>
+    </CacheProvider>
+  );
+};
+
+export default AddTask;

--- a/src/contents/components/AutoComplete.tsx
+++ b/src/contents/components/AutoComplete.tsx
@@ -6,13 +6,14 @@ import React, { useState, useMemo } from "react";
 type Props = {
   options: string[];
   onChange: (value: string) => void;
+  defaultValue?: string;
   required?: boolean;
   placeholder?: string;
   label?: string;
 };
 export const AutoComplete = (props: Props) => {
-  const { options, onChange, placeholder = "", label = "", required = false } = props;
-  const [value, setValue] = useState<string>("");
+  const { options, onChange, placeholder = "", label = "", required = false, defaultValue = "" } = props;
+  const [value, setValue] = useState<string>(defaultValue);
   const [isFocused, setIsFocused] = useState<boolean>(false);
 
   const onInput = async (value: string) => {

--- a/src/contents/components/originalTaskModal.tsx
+++ b/src/contents/components/originalTaskModal.tsx
@@ -11,15 +11,17 @@ type Props = {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
   onClose: (task?: Task) => void;
+  course?: string;
+  courseURL?: string;
 };
 export const OriginalTaskModal = (props: Props) => {
-  const { isOpen: open, setIsOpen, onClose = () => {} } = props;
+  const { isOpen: open, setIsOpen, onClose = () => {}, course = "", courseURL = "" } = props;
   const [subjects, setSubjects] = useState<string[]>([]);
 
   const [taskName, setTaskName] = useState<string>("");
   const [taskURL, setTaskURL] = useState<string>("");
-  const [subjectName, setSubjectName] = useState<string>("");
-  const [subjectURL, setSubjectURL] = useState<string>("");
+  const [subjectName, setSubjectName] = useState<string>(course);
+  const [subjectURL, setSubjectURL] = useState<string>(courseURL);
   const [taskDate, setTaskDate] = useState<string>("");
   const [taskTime, setTaskTime] = useState<string>("00:00");
 
@@ -83,6 +85,7 @@ export const OriginalTaskModal = (props: Props) => {
     <Modal title={chrome.i18n.getMessage("OriginalTaskAdd")} isOpen={open} setIsOpen={setIsOpen} onClose={onClose}>
       <Box display="flex" flexDirection="column" px={1} sx={{ gap: 1 }}>
         <AutoComplete
+          defaultValue={subjectName}
           options={subjects}
           onChange={onChangeSubject}
           label={chrome.i18n.getMessage("taskListSubject")}

--- a/src/contents/util/timetable.ts
+++ b/src/contents/util/timetable.ts
@@ -30,7 +30,7 @@ const centeringTimetable = async () => {
  * 休講の曜日や時間帯を非表示にする
  */
 const hideNoClassDay = async () => {
-  const timetableData = getLMS();
+  const timetableData = getLMS(document);
   if (!timetableData.find((data) => data.day === 6)) {
     const sats = Array.from(document.getElementsByClassName("6-yobicol"));
     for (const sat of sats) sat.remove();


### PR DESCRIPTION
## 概要

- [ ] 科目別ページから自作課題を追加する機能を追加した

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
<img width="457" alt="スクリーンショット 2024-05-13 2 02 28" src="https://github.com/scombz-utilities/scombz-utilities-react/assets/59430508/4f6b96c4-2a79-4d5c-8f1e-aba6547ede7e">

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### 種別

- [ ] optimisation - 既存機能修正・最適化
- [ ] bugfix - バグ修正
- [ ] newfunc - 新機能追加
- [ ] style - スタイル変更
- [ ] else - その他

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント
