### PR TITLE
Improve/options page

### DIFF
--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -272,8 +272,8 @@
     "description": "おすすめ設定"
   },
   "IOReset": {
-    "message": "インポート・エクスポート・初期化",
-    "description": "インポート・エクスポート・初期化"
+    "message": "設定の管理",
+    "description": "設定の管理"
   },
   "import": {
     "message": "インポート",

--- a/src/options/components/AdvancedOptions.tsx
+++ b/src/options/components/AdvancedOptions.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { useMemo } from "react";
 import { CustomRemovableList } from "./CustomRemovableList";
 import { CustomSelect } from "./CustomSelect";
@@ -34,7 +34,7 @@ export const AdvancedOptions = (props: Props) => {
   return (
     <Box>
       <Typography variant="h5">詳細設定</Typography>
-      <Box display="flex" flexDirection="column" gap={1} p={1}>
+      <Stack gap={1} p={1}>
         <CustomTextField
           i18nLabel="学籍番号"
           i18nCaption="ログイン時に使用する学籍番号を入力してください。"
@@ -170,7 +170,7 @@ export const AdvancedOptions = (props: Props) => {
           }}
           reset={() => setScombzData("coursePageMemo", [])}
         />
-      </Box>
+      </Stack>
     </Box>
   );
 };

--- a/src/options/components/AdvancedOptions.tsx
+++ b/src/options/components/AdvancedOptions.tsx
@@ -40,8 +40,8 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="ログイン時に使用する学籍番号を入力してください。"
           optionId="loginData.username"
           value={saves.settings.loginData.username.split("@")[0]}
-          onChange={(e) => {
-            const username = e.target.value.includes("@") ? e.target.value : e.target.value + "@sic";
+          onSaveButtonClick={(value) => {
+            const username = value.includes("@") ? value : value + "@sic";
             setSettings("loginData", { ...saves.settings.loginData, username });
           }}
         />
@@ -51,9 +51,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="ログイン時に使用するパスワードを入力してください。"
           optionId="loginData.password"
           value={saves.settings.loginData.password}
-          onChange={(_event) =>
-            setSettings("loginData", { ...saves.settings.loginData, password: _event.target.value })
-          }
+          onSaveButtonClick={(value) => setSettings("loginData", { ...saves.settings.loginData, password: value })}
         />
         <CustomRemovableList
           i18nLabel="授業内アンケートの課題表示"
@@ -85,7 +83,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの最大値を設定します。"
           optionId="sliderBarMax"
           value={saves.settings.sliderBarMax.toString()}
-          onChange={(e) => setSettings("sliderBarMax", parseInt(e.target.value, 10))}
+          onSaveButtonClick={(value) => setSettings("sliderBarMax", parseInt(value, 10))}
         />
         <CustomSelect
           i18nLabel="提出時間の初期値(分)"
@@ -103,7 +101,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="レポート提出時にファイル名自動入力ボタンを押した際に入力される文字列を変更します。"
           optionId="defaultInputName"
           value={saves.settings.defaultInputName}
-          onChange={(e) => setSettings("defaultInputName", e.target.value)}
+          onSaveButtonClick={(value) => setSettings("defaultInputName", value)}
         />
 
         <CustomTextField
@@ -112,10 +110,10 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="科目別ページの最大幅を設定します。"
           optionId="layout.maxWidthPx.subj"
           value={saves.settings.layout.maxWidthPx.subj.toString()}
-          onChange={(e) =>
+          onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,
-              maxWidthPx: { ...saves.settings.layout.maxWidthPx, subj: parseInt(e.target.value, 10) },
+              maxWidthPx: { ...saves.settings.layout.maxWidthPx, subj: parseInt(value, 10) },
             })
           }
         />
@@ -125,10 +123,10 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="LMSページの最大幅を設定します。"
           optionId="layout.maxWidthPx.lms"
           value={saves.settings.layout.maxWidthPx.lms.toString()}
-          onChange={(e) =>
+          onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,
-              maxWidthPx: { ...saves.settings.layout.maxWidthPx, lms: parseInt(e.target.value, 10) },
+              maxWidthPx: { ...saves.settings.layout.maxWidthPx, lms: parseInt(value, 10) },
             })
           }
         />
@@ -138,10 +136,10 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="課題提出ページの最大幅を設定します。"
           optionId="layout.maxWidthPx.task"
           value={saves.settings.layout.maxWidthPx.task.toString()}
-          onChange={(e) =>
+          onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,
-              maxWidthPx: { ...saves.settings.layout.maxWidthPx, task: parseInt(e.target.value, 10) },
+              maxWidthPx: { ...saves.settings.layout.maxWidthPx, task: parseInt(value, 10) },
             })
           }
         />

--- a/src/options/components/AdvancedOptions.tsx
+++ b/src/options/components/AdvancedOptions.tsx
@@ -38,7 +38,7 @@ export const AdvancedOptions = (props: Props) => {
         <CustomTextField
           i18nLabel="学籍番号"
           i18nCaption="ログイン時に使用する学籍番号を入力してください。"
-          id="loginData.username"
+          optionId="loginData.username"
           value={saves.settings.loginData.username.split("@")[0]}
           onChange={(e) => {
             const username = e.target.value.includes("@") ? e.target.value : e.target.value + "@sic";
@@ -49,7 +49,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nLabel="パスワード"
           type="password"
           i18nCaption="ログイン時に使用するパスワードを入力してください。"
-          id="loginData.password"
+          optionId="loginData.password"
           value={saves.settings.loginData.password}
           onChange={(_event) =>
             setSettings("loginData", { ...saves.settings.loginData, password: _event.target.value })
@@ -57,7 +57,7 @@ export const AdvancedOptions = (props: Props) => {
         />
         <CustomRemovableList
           i18nLabel="授業内アンケートの課題表示"
-          id="notifySurveySubjects"
+          optionId="notifySurveySubjects"
           i18nCaption="授業内アンケートを課題として表示する科目を選択します。"
           options={saves.settings.notifySurveySubjects.map((subject) => subject.name)}
           onChange={(idx) => {
@@ -69,7 +69,7 @@ export const AdvancedOptions = (props: Props) => {
 
         <CustomRemovableList
           i18nLabel="非表示課題リスト"
-          id="hiddenTaskIdList"
+          optionId="hiddenTaskIdList"
           i18nCaption="メニュー横ウィジェットの課題一覧に表示されない課題IDを入力します。 リストから削除すると、期限内のものは再度表示されるようになります。"
           options={hiddenTaskList}
           onChange={(idx) => {
@@ -83,7 +83,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nLabel="スライダーバーの最大値(分)"
           type="number"
           i18nCaption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの最大値を設定します。"
-          id="sliderBarMax"
+          optionId="sliderBarMax"
           value={saves.settings.sliderBarMax.toString()}
           onChange={(e) => setSettings("sliderBarMax", parseInt(e.target.value, 10))}
         />
@@ -101,7 +101,7 @@ export const AdvancedOptions = (props: Props) => {
         <CustomTextField
           i18nLabel="ファイル名の自動入力設定"
           i18nCaption="レポート提出時にファイル名自動入力ボタンを押した際に入力される文字列を変更します。"
-          id="defaultInputName"
+          optionId="defaultInputName"
           value={saves.settings.defaultInputName}
           onChange={(e) => setSettings("defaultInputName", e.target.value)}
         />
@@ -110,7 +110,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nLabel="レイアウト変更 科目別ページ最大幅(px)"
           type="number"
           i18nCaption="科目別ページの最大幅を設定します。"
-          id="layout.maxWidthPx.subj"
+          optionId="layout.maxWidthPx.subj"
           value={saves.settings.layout.maxWidthPx.subj.toString()}
           onChange={(e) =>
             setSettings("layout", {
@@ -123,7 +123,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nLabel="レイアウト変更 LMSページ最大幅(px)"
           type="number"
           i18nCaption="LMSページの最大幅を設定します。"
-          id="layout.maxWidthPx.lms"
+          optionId="layout.maxWidthPx.lms"
           value={saves.settings.layout.maxWidthPx.lms.toString()}
           onChange={(e) =>
             setSettings("layout", {
@@ -136,7 +136,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nLabel="レイアウト変更 課題提出ページ最大幅(px)"
           type="number"
           i18nCaption="課題提出ページの最大幅を設定します。"
-          id="layout.maxWidthPx.task"
+          optionId="layout.maxWidthPx.task"
           value={saves.settings.layout.maxWidthPx.task.toString()}
           onChange={(e) =>
             setSettings("layout", {
@@ -159,7 +159,7 @@ export const AdvancedOptions = (props: Props) => {
         />
         <CustomRemovableList
           i18nLabel="科目ページメモ"
-          id="coursePageMemo"
+          optionId="coursePageMemo"
           i18nCaption="科目ページに表示されるメモを設定します。"
           options={saves.scombzData.coursePageMemo.map(
             (memo) => `${memo.course ?? memo.id}: ${memo.memo.slice(0, 30)}`,

--- a/src/options/components/AdvancedOptions.tsx
+++ b/src/options/components/AdvancedOptions.tsx
@@ -90,7 +90,7 @@ export const AdvancedOptions = (props: Props) => {
         <CustomSelect
           label="提出時間の初期値(分)"
           caption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの初期値を設定します。"
-          id="timesBtnValue"
+          optionId="timesBtnValue"
           options={SLIDER_BAR_MINS.map((min, index) => ({
             value: index.toString(),
             label: min.join("分, ") + "分",
@@ -148,7 +148,7 @@ export const AdvancedOptions = (props: Props) => {
         <CustomSelect
           label="ヘッダアイコンのリンク先"
           caption="ヘッダのScombZアイコンをクリックした際のリンク先を設定します。"
-          id="headLinkTo"
+          optionId="headLinkTo"
           options={[
             { value: "/portal/home", label: "ホーム" },
             { value: "/lms/timetable", label: "LMS" },

--- a/src/options/components/AdvancedOptions.tsx
+++ b/src/options/components/AdvancedOptions.tsx
@@ -36,8 +36,8 @@ export const AdvancedOptions = (props: Props) => {
       <Typography variant="h5">詳細設定</Typography>
       <Box display="flex" flexDirection="column" gap={1} p={1}>
         <CustomTextField
-          label="学籍番号"
-          caption="ログイン時に使用する学籍番号を入力してください。"
+          i18nLabel="学籍番号"
+          i18nCaption="ログイン時に使用する学籍番号を入力してください。"
           id="loginData.username"
           value={saves.settings.loginData.username.split("@")[0]}
           onChange={(e) => {
@@ -46,9 +46,9 @@ export const AdvancedOptions = (props: Props) => {
           }}
         />
         <CustomTextField
-          label="パスワード"
+          i18nLabel="パスワード"
           type="password"
-          caption="ログイン時に使用するパスワードを入力してください。"
+          i18nCaption="ログイン時に使用するパスワードを入力してください。"
           id="loginData.password"
           value={saves.settings.loginData.password}
           onChange={(_event) =>
@@ -56,9 +56,9 @@ export const AdvancedOptions = (props: Props) => {
           }
         />
         <CustomRemovableList
-          label="授業内アンケートの課題表示"
+          i18nLabel="授業内アンケートの課題表示"
           id="notifySurveySubjects"
-          caption="授業内アンケートを課題として表示する科目を選択します。"
+          i18nCaption="授業内アンケートを課題として表示する科目を選択します。"
           options={saves.settings.notifySurveySubjects.map((subject) => subject.name)}
           onChange={(idx) => {
             const newSubjects = saves.settings.notifySurveySubjects.filter((_, i) => i !== idx);
@@ -68,9 +68,9 @@ export const AdvancedOptions = (props: Props) => {
         />
 
         <CustomRemovableList
-          label="非表示課題リスト"
+          i18nLabel="非表示課題リスト"
           id="hiddenTaskIdList"
-          caption="メニュー横ウィジェットの課題一覧に表示されない課題IDを入力します。 リストから削除すると、期限内のものは再度表示されるようになります。"
+          i18nCaption="メニュー横ウィジェットの課題一覧に表示されない課題IDを入力します。 リストから削除すると、期限内のものは再度表示されるようになります。"
           options={hiddenTaskList}
           onChange={(idx) => {
             const newIds = saves.settings.hiddenTaskIdList.filter((_, i) => i !== idx);
@@ -80,16 +80,16 @@ export const AdvancedOptions = (props: Props) => {
         />
 
         <CustomTextField
-          label="スライダーバーの最大値(分)"
+          i18nLabel="スライダーバーの最大値(分)"
           type="number"
-          caption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの最大値を設定します。"
+          i18nCaption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの最大値を設定します。"
           id="sliderBarMax"
           value={saves.settings.sliderBarMax.toString()}
           onChange={(e) => setSettings("sliderBarMax", parseInt(e.target.value, 10))}
         />
         <CustomSelect
-          label="提出時間の初期値(分)"
-          caption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの初期値を設定します。"
+          i18nLabel="提出時間の初期値(分)"
+          i18nCaption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの初期値を設定します。"
           optionId="timesBtnValue"
           options={SLIDER_BAR_MINS.map((min, index) => ({
             value: index.toString(),
@@ -99,17 +99,17 @@ export const AdvancedOptions = (props: Props) => {
           onChange={(e, _) => setSettings("timesBtnValue", parseInt(e.target.value, 10))}
         />
         <CustomTextField
-          label="ファイル名の自動入力設定"
-          caption="レポート提出時にファイル名自動入力ボタンを押した際に入力される文字列を変更します。"
+          i18nLabel="ファイル名の自動入力設定"
+          i18nCaption="レポート提出時にファイル名自動入力ボタンを押した際に入力される文字列を変更します。"
           id="defaultInputName"
           value={saves.settings.defaultInputName}
           onChange={(e) => setSettings("defaultInputName", e.target.value)}
         />
 
         <CustomTextField
-          label="レイアウト変更 科目別ページ最大幅(px)"
+          i18nLabel="レイアウト変更 科目別ページ最大幅(px)"
           type="number"
-          caption="科目別ページの最大幅を設定します。"
+          i18nCaption="科目別ページの最大幅を設定します。"
           id="layout.maxWidthPx.subj"
           value={saves.settings.layout.maxWidthPx.subj.toString()}
           onChange={(e) =>
@@ -120,9 +120,9 @@ export const AdvancedOptions = (props: Props) => {
           }
         />
         <CustomTextField
-          label="レイアウト変更 LMSページ最大幅(px)"
+          i18nLabel="レイアウト変更 LMSページ最大幅(px)"
           type="number"
-          caption="LMSページの最大幅を設定します。"
+          i18nCaption="LMSページの最大幅を設定します。"
           id="layout.maxWidthPx.lms"
           value={saves.settings.layout.maxWidthPx.lms.toString()}
           onChange={(e) =>
@@ -133,9 +133,9 @@ export const AdvancedOptions = (props: Props) => {
           }
         />
         <CustomTextField
-          label="レイアウト変更 課題提出ページ最大幅(px)"
+          i18nLabel="レイアウト変更 課題提出ページ最大幅(px)"
           type="number"
-          caption="課題提出ページの最大幅を設定します。"
+          i18nCaption="課題提出ページの最大幅を設定します。"
           id="layout.maxWidthPx.task"
           value={saves.settings.layout.maxWidthPx.task.toString()}
           onChange={(e) =>
@@ -146,8 +146,8 @@ export const AdvancedOptions = (props: Props) => {
           }
         />
         <CustomSelect
-          label="ヘッダアイコンのリンク先"
-          caption="ヘッダのScombZアイコンをクリックした際のリンク先を設定します。"
+          i18nLabel="ヘッダアイコンのリンク先"
+          i18nCaption="ヘッダのScombZアイコンをクリックした際のリンク先を設定します。"
           optionId="headLinkTo"
           options={[
             { value: "/portal/home", label: "ホーム" },
@@ -158,9 +158,9 @@ export const AdvancedOptions = (props: Props) => {
           onChange={(e, _) => setSettings("headLinkTo", e.target.value)}
         />
         <CustomRemovableList
-          label="科目ページメモ"
+          i18nLabel="科目ページメモ"
           id="coursePageMemo"
-          caption="科目ページに表示されるメモを設定します。"
+          i18nCaption="科目ページに表示されるメモを設定します。"
           options={saves.scombzData.coursePageMemo.map(
             (memo) => `${memo.course ?? memo.id}: ${memo.memo.slice(0, 30)}`,
           )}

--- a/src/options/components/BasicOptions.tsx
+++ b/src/options/components/BasicOptions.tsx
@@ -16,9 +16,9 @@ export const BasicOptions = (props: Props) => {
       <Typography variant="h5">基本設定</Typography>
       <Box display="flex" flexDirection="column" gap={1} p={1}>
         <CustomSelect
-          label="学部"
+          i18nLabel="学部"
           optionId="faculty"
-          caption="学部を選択してください。学部情報は、ScombZとシラバス間の連携機能にのみ使用されます。"
+          i18nCaption="学部を選択してください。学部情報は、ScombZとシラバス間の連携機能にのみ使用されます。"
           options={[
             { value: "din", label: "大学院" },
             { value: "ko1", label: "工学部" },
@@ -30,15 +30,15 @@ export const BasicOptions = (props: Props) => {
           onChange={(e, _) => setSettings("faculty", e.target.value)}
         />
         <CustomSwitch
-          label="ログインボタン自動クリック"
-          caption="ScombZのログイン画面に遷移した際、学生ログインを自動でクリックします。"
+          i18nLabel="ログインボタン自動クリック"
+          i18nCaption="ScombZのログイン画面に遷移した際、学生ログインを自動でクリックします。"
           id="clickLogin"
           value={saves.settings.clickLogin}
           onChange={(_e, checked) => setSettings("clickLogin", checked)}
         />
         <CustomSwitch
-          label="自動ログイン"
-          caption={`ログイン情報を自動入力し、ADFS二段階認証確認画面の次へボタンを自動でクリックします。
+          i18nLabel="自動ログイン"
+          i18nCaption={`ログイン情報を自動入力し、ADFS二段階認証確認画面の次へボタンを自動でクリックします。
             ログイン後、自動でScombZの画面に入れます。
             スマートフォンを利用した二段階認証にも対応しています。
             ※登録した情報は「詳細設定タブ」から確認・変更ができます。`}
@@ -47,16 +47,16 @@ export const BasicOptions = (props: Props) => {
           onChange={(_e, checked) => setSettings("autoAdfs", checked)}
         />
         <CustomSwitch
-          label="未提出課題数のバッジ表示"
-          caption="未提出の課題の個数をバッジに表示します。"
+          i18nLabel="未提出課題数のバッジ表示"
+          i18nCaption="未提出の課題の個数をバッジに表示します。"
           id="popupBadge"
           value={saves.settings.popupBadge}
           onChange={(_e, checked) => setSettings("popupBadge", checked)}
         />
         <CustomSelect
-          label="出欠表示削除"
+          i18nLabel="出欠表示削除"
           optionId="removeAttendance"
-          caption="科目ページの最下部にある出欠表示を削除します。 ※表示のみを削除することも可能です。"
+          i18nCaption="科目ページの最下部にある出欠表示を削除します。 ※表示のみを削除することも可能です。"
           options={[
             { value: "none", label: "削除しない" },
             { value: "only", label: "出席表示が※の科目のみ" },
@@ -66,22 +66,22 @@ export const BasicOptions = (props: Props) => {
           onChange={(e, _) => setSettings("removeAttendance", e.target.value)}
         />
         <CustomSwitch
-          label="S*gsot学番自動入力"
-          caption="S*gsotのログイン時、ユーザー名入力欄に学籍番号を自動入力します。"
+          i18nLabel="S*gsot学番自動入力"
+          i18nCaption="S*gsotのログイン時、ユーザー名入力欄に学籍番号を自動入力します。"
           id="autoFillSgsot"
           value={saves.settings.autoFillSgsot}
           onChange={(_e, checked) => setSettings("autoFillSgsot", checked)}
         />
         <CustomSwitch
-          label="時間割 現在の授業を目立たせる"
-          caption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
+          i18nLabel="時間割 現在の授業を目立たせる"
+          i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
           id="highlightToday"
           value={saves.settings.highlightToday}
           onChange={(_e, checked) => setSettings("highlightToday", checked)}
         />
         <CustomSwitch
-          label="サイドメニューを自動で閉じる"
-          caption={`ScombZの左側に表示されるサイドメニューを、常に閉じた状態でページ読み込みします。
+          i18nLabel="サイドメニューを自動で閉じる"
+          i18nCaption={`ScombZの左側に表示されるサイドメニューを、常に閉じた状態でページ読み込みします。
                       メニューボタンを押すことで展開できます。
                       左メニュースタイル変更をオンにしている場合は、本項目もオンにすることが推奨されます。`}
           id="hideSideMenu"
@@ -89,166 +89,166 @@ export const BasicOptions = (props: Props) => {
           onChange={(_e, checked) => setSettings("hideSideMenu", checked)}
         />
         <CustomSwitch
-          label="サイドメニューのスタイル変更"
-          caption={`ScombZの左側に表示されるサイドメニューを、ユーザビリティに配慮したスタイルに変更します。
+          i18nLabel="サイドメニューのスタイル変更"
+          i18nCaption={`ScombZの左側に表示されるサイドメニューを、ユーザビリティに配慮したスタイルに変更します。
                       表示だけでなく、グレーの部分をクリックすることによっても、メニューを閉じられるようになります。`}
           id="styleSideMenu"
           value={saves.settings.styleSideMenu}
           onChange={(_e, checked) => setSettings("styleSideMenu", checked)}
         />
         <CustomSwitch
-          label="お知らせダイアログを大きくする"
-          caption={`ScombZのお知らせなどのダイアログを、ウィンドウのサイズまで拡張して見やすくします。
+          i18nLabel="お知らせダイアログを大きくする"
+          i18nCaption={`ScombZのお知らせなどのダイアログを、ウィンドウのサイズまで拡張して見やすくします。
                       また、ダイアログの外をクリックすることでもダイアログを閉じられるようになります。`}
           id="styleDialog"
           value={saves.settings.styleDialog}
           onChange={(_e, checked) => setSettings("styleDialog", checked)}
         />
         <CustomSwitch
-          label="アンケートのレイアウト最適化"
-          caption={`アンケート画面のレイアウトを最適化します。`}
+          i18nLabel="アンケートのレイアウト最適化"
+          i18nCaption={`アンケート画面のレイアウトを最適化します。`}
           id="styleSurveys"
           value={saves.settings.styleSurveys}
           onChange={(_e, checked) => setSettings("styleSurveys", checked)}
         />
         <CustomSwitch
-          label="テストのレイアウト最適化"
-          caption={`テスト画面のレイアウトを最適化します。`}
+          i18nLabel="テストのレイアウト最適化"
+          i18nCaption={`テスト画面のレイアウトを最適化します。`}
           id="useSubTimeTable"
           value={saves.settings.useSubTimeTable}
           onChange={(_e, checked) => setSettings("useSubTimeTable", checked)}
         />
         <CustomSwitch
-          label="レポート提出ボタンの変更"
-          caption="レポート提出画面に、制作時間の簡易入力ボタンを追加します。また、提出ボタンをユーザビリティに配慮した色や配置にします。"
+          i18nLabel="レポート提出ボタンの変更"
+          i18nCaption="レポート提出画面に、制作時間の簡易入力ボタンを追加します。また、提出ボタンをユーザビリティに配慮した色や配置にします。"
           id="changeReportBtn"
           value={saves.settings.changeReportBtn}
           onChange={(_e, checked) => setSettings("changeReportBtn", checked)}
         />
         <CustomSwitch
-          label="LMSページのレイアウト変更 教室表示"
-          caption="LMSページで、教室情報を常に表示します。"
+          i18nLabel="LMSページのレイアウト変更 教室表示"
+          i18nCaption="LMSページで、教室情報を常に表示します。"
           id="lms.showClassroom"
           value={saves.settings.lms.showClassroom}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, showClassroom: checked })}
         />
         <CustomSwitch
-          label="LMSページのレイアウト変更 文字センタリング"
-          caption="LMSページで、文字を中央揃えにします。"
+          i18nLabel="LMSページのレイアウト変更 文字センタリング"
+          i18nCaption="LMSページで、文字を中央揃えにします。"
           id="lms.centering"
           value={saves.settings.lms.centering}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, centering: checked })}
         />
         <CustomSwitch
-          label="LMSページのレイアウト変更 休日非表示"
-          caption="LMSページで、授業のない日を非表示にします。 また、5限以降の授業をとっていない場合はそれらも非表示にします。"
+          i18nLabel="LMSページのレイアウト変更 休日非表示"
+          i18nCaption="LMSページで、授業のない日を非表示にします。 また、5限以降の授業をとっていない場合はそれらも非表示にします。"
           id="lms.hideNoClassDay"
           value={saves.settings.lms.hideNoClassDay}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, hideNoClassDay: checked })}
         />
 
         <CustomSwitch
-          label="更新通知全削除ボタン追加"
-          caption="ページ上部に表示されるバナーにある更新通知ボタンの右側に、全ての更新通知を一括で削除するボタンを追加します。"
+          i18nLabel="更新通知全削除ボタン追加"
+          i18nCaption="ページ上部に表示されるバナーにある更新通知ボタンの右側に、全ての更新通知を一括で削除するボタンを追加します。"
           id="updateClear"
           value={saves.settings.updateClear}
           onChange={(_e, checked) => setSettings("updateClear", checked)}
         />
         <CustomSwitch
-          label="課題削除できないバグの修正"
-          caption="課題提出画面の成果物提出を削除するとき、ドラッグ&ドロップ状態になっていると画面に何も表示されなくなり何もできなくなるという、ScombZ本体のバグを修正します。"
+          i18nLabel="課題削除できないバグの修正"
+          i18nCaption="課題提出画面の成果物提出を削除するとき、ドラッグ&ドロップ状態になっていると画面に何も表示されなくなり何もできなくなるという、ScombZ本体のバグを修正します。"
           id="dragAndDropBugFix"
           value={saves.settings.dragAndDropBugFix}
           onChange={(_e, checked) => setSettings("dragAndDropBugFix", checked)}
         />
         <CustomSwitch
-          label="課題ドラッグ&ドロップ提出"
-          caption="課題提出画面の成果物提出欄をクリックなしで最初からドラッグ&ドロップにします。"
+          i18nLabel="課題ドラッグ&ドロップ提出"
+          i18nCaption="課題提出画面の成果物提出欄をクリックなしで最初からドラッグ&ドロップにします。"
           id="forceDragAndDropSubmit"
           value={saves.settings.forceDragAndDropSubmit}
           onChange={(_e, checked) => setSettings("forceDragAndDropSubmit", checked)}
         />
         <CustomSwitch
-          label="ファイル一括ダウンロード"
-          caption="科目詳細ページ内において、配布されているすべてのpdfファイルをZIP形式に圧縮し一括でダウンロードする機能です。"
+          i18nLabel="ファイル一括ダウンロード"
+          i18nCaption="科目詳細ページ内において、配布されているすべてのpdfファイルをZIP形式に圧縮し一括でダウンロードする機能です。"
           id="downloadFileBundle"
           value={saves.settings.downloadFileBundle}
           onChange={(_e, checked) => setSettings("downloadFileBundle", checked)}
         />
         <CustomSwitch
-          label="提出済み課題を非表示"
-          caption="ScombZのホーム画面に表示されるカレンダーにおいて、既に提出済みである課題を非表示にします。"
+          i18nLabel="提出済み課題を非表示"
+          i18nCaption="ScombZのホーム画面に表示されるカレンダーにおいて、既に提出済みである課題を非表示にします。"
           id="hideCompletedReports"
           value={saves.settings.hideCompletedReports}
           onChange={(_e, checked) => setSettings("hideCompletedReports", checked)}
         />
         <CustomSwitch
-          label="サインアウトページのレイアウト変更"
-          caption="サインアウトページのレイアウトを最適化します。"
+          i18nLabel="サインアウトページのレイアウト変更"
+          i18nCaption="サインアウトページのレイアウトを最適化します。"
           id="signOutPageLayout"
           value={saves.settings.signOutPageLayout}
           onChange={(_e, checked) => setSettings("signOutPageLayout", checked)}
         />
         <CustomSwitch
-          label="レイアウト変更 最大幅を有効化"
-          caption="ページの最大幅の有効/無効を設定します。"
+          i18nLabel="レイアウト変更 最大幅を有効化"
+          i18nCaption="ページの最大幅の有効/無効を設定します。"
           id="layout.setMaxWidth"
           value={saves.settings.layout.setMaxWidth}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, setMaxWidth: checked })}
         />
 
         <CustomSwitch
-          label="レイアウト変更 ページトップボタン非表示"
-          caption="ページ最上部へのボタンを非表示にします。"
+          i18nLabel="レイアウト変更 ページトップボタン非表示"
+          i18nCaption="ページ最上部へのボタンを非表示にします。"
           id="layout.removePageTop"
           value={saves.settings.layout.removePageTop}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, removePageTop: checked })}
         />
         <CustomSwitch
-          label="レイアウト変更 ダイレクトリンク非表示"
-          caption="ページ最下部に表示されるダイレクトリンクを非表示にします。"
+          i18nLabel="レイアウト変更 ダイレクトリンク非表示"
+          i18nCaption="ページ最下部に表示されるダイレクトリンクを非表示にします。"
           id="layout.removeDirectLink"
           value={saves.settings.layout.removeDirectLink}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, removeDirectLink: checked })}
         />
         <CustomSwitch
-          label="レイアウト変更 トップページレイアウト変更"
-          caption="トップページのレイアウトを最適化します。"
+          i18nLabel="レイアウト変更 トップページレイアウト変更"
+          i18nCaption="トップページのレイアウトを最適化します。"
           id="layout.topPageLayout"
           value={saves.settings.layout.topPageLayout}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, topPageLayout: checked })}
         />
         <CustomSwitch
-          label="レイアウト変更 名前非表示"
-          caption="名前をクリックして非表示にできるようにします。"
+          i18nLabel="レイアウト変更 名前非表示"
+          i18nCaption="名前をクリックして非表示にできるようにします。"
           id="layout.clickToHideName"
           value={saves.settings.layout.clickToHideName}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, clickToHideName: checked })}
         />
         <CustomSwitch
-          label="科目ページ リンク化"
-          caption="科目別のページ内において、テキスト内のURLをリンク化します。"
+          i18nLabel="科目ページ リンク化"
+          i18nCaption="科目別のページ内において、テキスト内のURLをリンク化します。"
           id="layout.linkify"
           value={saves.settings.layout.linkify}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, linkify: checked })}
         />
         <CustomSwitch
-          label="科目ページ タイトル変更"
-          caption="科目別のページ内において、ページタイトルをわかりやすいものに変更します。"
+          i18nLabel="科目ページ タイトル変更"
+          i18nCaption="科目別のページ内において、ページタイトルをわかりやすいものに変更します。"
           id="modifyCoursePageTitle"
           value={saves.settings.modifyCoursePageTitle}
           onChange={(_e, checked) => setSettings("modifyCoursePageTitle", checked)}
         />
         <CustomSwitch
-          label="特殊リンクにおけるホイールクリックと右クリックの有効化"
-          caption="LMSページ内の科目ボタン、科目別ページのダウンロードリンクなど、右クリックが通常できないリンクを通常のリンクと同じようにサポートします。"
+          i18nLabel="特殊リンクにおけるホイールクリックと右クリックの有効化"
+          i18nCaption="LMSページ内の科目ボタン、科目別ページのダウンロードリンクなど、右クリックが通常できないリンクを通常のリンクと同じようにサポートします。"
           id="modifyClickableLinks"
           value={saves.settings.modifyClickableLinks}
           onChange={(_e, checked) => setSettings("modifyClickableLinks", checked)}
         />
         <CustomSwitch
-          label="科目ページ マークダウンメモ帳"
-          caption="科目別ページ内において、マークダウン記法に対応したメモ帳を追加します。"
+          i18nLabel="科目ページ マークダウンメモ帳"
+          i18nCaption="科目別ページ内において、マークダウン記法に対応したメモ帳を追加します。"
           id="markdownNotePad"
           value={saves.settings.markdownNotePad}
           onChange={(_e, checked) => setSettings("markdownNotePad", checked)}

--- a/src/options/components/BasicOptions.tsx
+++ b/src/options/components/BasicOptions.tsx
@@ -32,7 +32,7 @@ export const BasicOptions = (props: Props) => {
         <CustomSwitch
           i18nLabel="ログインボタン自動クリック"
           i18nCaption="ScombZのログイン画面に遷移した際、学生ログインを自動でクリックします。"
-          id="clickLogin"
+          optionId="clickLogin"
           value={saves.settings.clickLogin}
           onChange={(_e, checked) => setSettings("clickLogin", checked)}
         />
@@ -42,14 +42,14 @@ export const BasicOptions = (props: Props) => {
             ログイン後、自動でScombZの画面に入れます。
             スマートフォンを利用した二段階認証にも対応しています。
             ※登録した情報は「詳細設定タブ」から確認・変更ができます。`}
-          id="autoAdfs"
+          optionId="autoAdfs"
           value={saves.settings.autoAdfs}
           onChange={(_e, checked) => setSettings("autoAdfs", checked)}
         />
         <CustomSwitch
           i18nLabel="未提出課題数のバッジ表示"
           i18nCaption="未提出の課題の個数をバッジに表示します。"
-          id="popupBadge"
+          optionId="popupBadge"
           value={saves.settings.popupBadge}
           onChange={(_e, checked) => setSettings("popupBadge", checked)}
         />
@@ -68,14 +68,14 @@ export const BasicOptions = (props: Props) => {
         <CustomSwitch
           i18nLabel="S*gsot学番自動入力"
           i18nCaption="S*gsotのログイン時、ユーザー名入力欄に学籍番号を自動入力します。"
-          id="autoFillSgsot"
+          optionId="autoFillSgsot"
           value={saves.settings.autoFillSgsot}
           onChange={(_e, checked) => setSettings("autoFillSgsot", checked)}
         />
         <CustomSwitch
           i18nLabel="時間割 現在の授業を目立たせる"
           i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
-          id="highlightToday"
+          optionId="highlightToday"
           value={saves.settings.highlightToday}
           onChange={(_e, checked) => setSettings("highlightToday", checked)}
         />
@@ -84,7 +84,7 @@ export const BasicOptions = (props: Props) => {
           i18nCaption={`ScombZの左側に表示されるサイドメニューを、常に閉じた状態でページ読み込みします。
                       メニューボタンを押すことで展開できます。
                       左メニュースタイル変更をオンにしている場合は、本項目もオンにすることが推奨されます。`}
-          id="hideSideMenu"
+          optionId="hideSideMenu"
           value={saves.settings.hideSideMenu}
           onChange={(_e, checked) => setSettings("hideSideMenu", checked)}
         />
@@ -92,7 +92,7 @@ export const BasicOptions = (props: Props) => {
           i18nLabel="サイドメニューのスタイル変更"
           i18nCaption={`ScombZの左側に表示されるサイドメニューを、ユーザビリティに配慮したスタイルに変更します。
                       表示だけでなく、グレーの部分をクリックすることによっても、メニューを閉じられるようになります。`}
-          id="styleSideMenu"
+          optionId="styleSideMenu"
           value={saves.settings.styleSideMenu}
           onChange={(_e, checked) => setSettings("styleSideMenu", checked)}
         />
@@ -100,49 +100,49 @@ export const BasicOptions = (props: Props) => {
           i18nLabel="お知らせダイアログを大きくする"
           i18nCaption={`ScombZのお知らせなどのダイアログを、ウィンドウのサイズまで拡張して見やすくします。
                       また、ダイアログの外をクリックすることでもダイアログを閉じられるようになります。`}
-          id="styleDialog"
+          optionId="styleDialog"
           value={saves.settings.styleDialog}
           onChange={(_e, checked) => setSettings("styleDialog", checked)}
         />
         <CustomSwitch
           i18nLabel="アンケートのレイアウト最適化"
           i18nCaption={`アンケート画面のレイアウトを最適化します。`}
-          id="styleSurveys"
+          optionId="styleSurveys"
           value={saves.settings.styleSurveys}
           onChange={(_e, checked) => setSettings("styleSurveys", checked)}
         />
         <CustomSwitch
           i18nLabel="テストのレイアウト最適化"
           i18nCaption={`テスト画面のレイアウトを最適化します。`}
-          id="useSubTimeTable"
+          optionId="useSubTimeTable"
           value={saves.settings.useSubTimeTable}
           onChange={(_e, checked) => setSettings("useSubTimeTable", checked)}
         />
         <CustomSwitch
           i18nLabel="レポート提出ボタンの変更"
           i18nCaption="レポート提出画面に、制作時間の簡易入力ボタンを追加します。また、提出ボタンをユーザビリティに配慮した色や配置にします。"
-          id="changeReportBtn"
+          optionId="changeReportBtn"
           value={saves.settings.changeReportBtn}
           onChange={(_e, checked) => setSettings("changeReportBtn", checked)}
         />
         <CustomSwitch
           i18nLabel="LMSページのレイアウト変更 教室表示"
           i18nCaption="LMSページで、教室情報を常に表示します。"
-          id="lms.showClassroom"
+          optionId="lms.showClassroom"
           value={saves.settings.lms.showClassroom}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, showClassroom: checked })}
         />
         <CustomSwitch
           i18nLabel="LMSページのレイアウト変更 文字センタリング"
           i18nCaption="LMSページで、文字を中央揃えにします。"
-          id="lms.centering"
+          optionId="lms.centering"
           value={saves.settings.lms.centering}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, centering: checked })}
         />
         <CustomSwitch
           i18nLabel="LMSページのレイアウト変更 休日非表示"
           i18nCaption="LMSページで、授業のない日を非表示にします。 また、5限以降の授業をとっていない場合はそれらも非表示にします。"
-          id="lms.hideNoClassDay"
+          optionId="lms.hideNoClassDay"
           value={saves.settings.lms.hideNoClassDay}
           onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, hideNoClassDay: checked })}
         />
@@ -150,49 +150,49 @@ export const BasicOptions = (props: Props) => {
         <CustomSwitch
           i18nLabel="更新通知全削除ボタン追加"
           i18nCaption="ページ上部に表示されるバナーにある更新通知ボタンの右側に、全ての更新通知を一括で削除するボタンを追加します。"
-          id="updateClear"
+          optionId="updateClear"
           value={saves.settings.updateClear}
           onChange={(_e, checked) => setSettings("updateClear", checked)}
         />
         <CustomSwitch
           i18nLabel="課題削除できないバグの修正"
           i18nCaption="課題提出画面の成果物提出を削除するとき、ドラッグ&ドロップ状態になっていると画面に何も表示されなくなり何もできなくなるという、ScombZ本体のバグを修正します。"
-          id="dragAndDropBugFix"
+          optionId="dragAndDropBugFix"
           value={saves.settings.dragAndDropBugFix}
           onChange={(_e, checked) => setSettings("dragAndDropBugFix", checked)}
         />
         <CustomSwitch
           i18nLabel="課題ドラッグ&ドロップ提出"
           i18nCaption="課題提出画面の成果物提出欄をクリックなしで最初からドラッグ&ドロップにします。"
-          id="forceDragAndDropSubmit"
+          optionId="forceDragAndDropSubmit"
           value={saves.settings.forceDragAndDropSubmit}
           onChange={(_e, checked) => setSettings("forceDragAndDropSubmit", checked)}
         />
         <CustomSwitch
           i18nLabel="ファイル一括ダウンロード"
           i18nCaption="科目詳細ページ内において、配布されているすべてのpdfファイルをZIP形式に圧縮し一括でダウンロードする機能です。"
-          id="downloadFileBundle"
+          optionId="downloadFileBundle"
           value={saves.settings.downloadFileBundle}
           onChange={(_e, checked) => setSettings("downloadFileBundle", checked)}
         />
         <CustomSwitch
           i18nLabel="提出済み課題を非表示"
           i18nCaption="ScombZのホーム画面に表示されるカレンダーにおいて、既に提出済みである課題を非表示にします。"
-          id="hideCompletedReports"
+          optionId="hideCompletedReports"
           value={saves.settings.hideCompletedReports}
           onChange={(_e, checked) => setSettings("hideCompletedReports", checked)}
         />
         <CustomSwitch
           i18nLabel="サインアウトページのレイアウト変更"
           i18nCaption="サインアウトページのレイアウトを最適化します。"
-          id="signOutPageLayout"
+          optionId="signOutPageLayout"
           value={saves.settings.signOutPageLayout}
           onChange={(_e, checked) => setSettings("signOutPageLayout", checked)}
         />
         <CustomSwitch
           i18nLabel="レイアウト変更 最大幅を有効化"
           i18nCaption="ページの最大幅の有効/無効を設定します。"
-          id="layout.setMaxWidth"
+          optionId="layout.setMaxWidth"
           value={saves.settings.layout.setMaxWidth}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, setMaxWidth: checked })}
         />
@@ -200,56 +200,56 @@ export const BasicOptions = (props: Props) => {
         <CustomSwitch
           i18nLabel="レイアウト変更 ページトップボタン非表示"
           i18nCaption="ページ最上部へのボタンを非表示にします。"
-          id="layout.removePageTop"
+          optionId="layout.removePageTop"
           value={saves.settings.layout.removePageTop}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, removePageTop: checked })}
         />
         <CustomSwitch
           i18nLabel="レイアウト変更 ダイレクトリンク非表示"
           i18nCaption="ページ最下部に表示されるダイレクトリンクを非表示にします。"
-          id="layout.removeDirectLink"
+          optionId="layout.removeDirectLink"
           value={saves.settings.layout.removeDirectLink}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, removeDirectLink: checked })}
         />
         <CustomSwitch
           i18nLabel="レイアウト変更 トップページレイアウト変更"
           i18nCaption="トップページのレイアウトを最適化します。"
-          id="layout.topPageLayout"
+          optionId="layout.topPageLayout"
           value={saves.settings.layout.topPageLayout}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, topPageLayout: checked })}
         />
         <CustomSwitch
           i18nLabel="レイアウト変更 名前非表示"
           i18nCaption="名前をクリックして非表示にできるようにします。"
-          id="layout.clickToHideName"
+          optionId="layout.clickToHideName"
           value={saves.settings.layout.clickToHideName}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, clickToHideName: checked })}
         />
         <CustomSwitch
           i18nLabel="科目ページ リンク化"
           i18nCaption="科目別のページ内において、テキスト内のURLをリンク化します。"
-          id="layout.linkify"
+          optionId="layout.linkify"
           value={saves.settings.layout.linkify}
           onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, linkify: checked })}
         />
         <CustomSwitch
           i18nLabel="科目ページ タイトル変更"
           i18nCaption="科目別のページ内において、ページタイトルをわかりやすいものに変更します。"
-          id="modifyCoursePageTitle"
+          optionId="modifyCoursePageTitle"
           value={saves.settings.modifyCoursePageTitle}
           onChange={(_e, checked) => setSettings("modifyCoursePageTitle", checked)}
         />
         <CustomSwitch
           i18nLabel="特殊リンクにおけるホイールクリックと右クリックの有効化"
           i18nCaption="LMSページ内の科目ボタン、科目別ページのダウンロードリンクなど、右クリックが通常できないリンクを通常のリンクと同じようにサポートします。"
-          id="modifyClickableLinks"
+          optionId="modifyClickableLinks"
           value={saves.settings.modifyClickableLinks}
           onChange={(_e, checked) => setSettings("modifyClickableLinks", checked)}
         />
         <CustomSwitch
           i18nLabel="科目ページ マークダウンメモ帳"
           i18nCaption="科目別ページ内において、マークダウン記法に対応したメモ帳を追加します。"
-          id="markdownNotePad"
+          optionId="markdownNotePad"
           value={saves.settings.markdownNotePad}
           onChange={(_e, checked) => setSettings("markdownNotePad", checked)}
         />

--- a/src/options/components/BasicOptions.tsx
+++ b/src/options/components/BasicOptions.tsx
@@ -17,7 +17,7 @@ export const BasicOptions = (props: Props) => {
       <Box display="flex" flexDirection="column" gap={1} p={1}>
         <CustomSelect
           label="学部"
-          id="faculty"
+          optionId="faculty"
           caption="学部を選択してください。学部情報は、ScombZとシラバス間の連携機能にのみ使用されます。"
           options={[
             { value: "din", label: "大学院" },
@@ -55,7 +55,7 @@ export const BasicOptions = (props: Props) => {
         />
         <CustomSelect
           label="出欠表示削除"
-          id="removeAttendance"
+          optionId="removeAttendance"
           caption="科目ページの最下部にある出欠表示を削除します。 ※表示のみを削除することも可能です。"
           options={[
             { value: "none", label: "削除しない" },

--- a/src/options/components/BasicOptions.tsx
+++ b/src/options/components/BasicOptions.tsx
@@ -16,9 +16,9 @@ export const BasicOptions = (props: Props) => {
       <Typography variant="h5">基本設定</Typography>
       <Box display="flex" flexDirection="column" gap={1} p={1}>
         <CustomSelect
-          i18nLabel="学部"
+          i18nLabel="在籍学部"
           optionId="faculty"
-          i18nCaption="学部を選択してください。学部情報は、ScombZとシラバス間の連携機能にのみ使用されます。"
+          i18nCaption="学部情報をもとに、科目別ページにシラバスへのリンクを表示します。"
           options={[
             { value: "din", label: "大学院" },
             { value: "ko1", label: "工学部" },
@@ -71,13 +71,6 @@ export const BasicOptions = (props: Props) => {
           optionId="autoFillSgsot"
           value={saves.settings.autoFillSgsot}
           onChange={(_e, checked) => setSettings("autoFillSgsot", checked)}
-        />
-        <CustomSwitch
-          i18nLabel="時間割 現在の授業を目立たせる"
-          i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
-          optionId="highlightToday"
-          value={saves.settings.highlightToday}
-          onChange={(_e, checked) => setSettings("highlightToday", checked)}
         />
         <CustomSwitch
           i18nLabel="サイドメニューを自動で閉じる"

--- a/src/options/components/ComplexOptions.tsx
+++ b/src/options/components/ComplexOptions.tsx
@@ -41,7 +41,7 @@ export const ComplexOptions = (props: Props) => {
           <Tab label="ウィジェット設定" />
           <Tab label="詳細設定" />
           <Tab label="カスタムCSS" />
-          <Tab label="インポート・エクスポート・初期化" />
+          <Tab label="設定の管理" />
           <Tab label="情報" />
         </Tabs>
       </Box>

--- a/src/options/components/ComplexOptions.tsx
+++ b/src/options/components/ComplexOptions.tsx
@@ -51,7 +51,7 @@ export const ComplexOptions = (props: Props) => {
         {tabIndex === 1 && <WidgetOptions saves={saves} setSettings={setSettings} />}
         {tabIndex === 2 && <AdvancedOptions saves={saves} setSettings={setSettings} setScombzData={setScombzData} />}
         {tabIndex === 3 && (
-          <CustomCSS value={saves.settings.customCSS} onChange={(value) => setSettings("customCSS", value)} />
+          <CustomCSS value={saves.settings.customCSS} onSaveButtonClick={(value) => setSettings("customCSS", value)} />
         )}
         {tabIndex === 4 && <DataOperation saves={saves} setSaves={setSaves} />}
         {tabIndex === 5 && <Information />}

--- a/src/options/components/CustomCSS.tsx
+++ b/src/options/components/CustomCSS.tsx
@@ -1,18 +1,34 @@
-import { Box, Typography } from "@mui/material";
+import { Save } from "@mui/icons-material";
+import { Box, Button, Typography } from "@mui/material";
+import { useState } from "react";
 import { Editor } from "./Editor";
 
 type Props = {
   value: string;
-  onChange: (value: string) => void;
+  onSaveButtonClick: (value: string) => void;
 };
+
 export const CustomCSS = (props: Props) => {
-  const { value, onChange } = props;
+  const { value, onSaveButtonClick } = props;
+
+  const [currentValue, setCurrentValue] = useState(value);
+
   return (
     <Box>
       <Typography variant="h5" mb={1}>
         カスタムCSS
       </Typography>
-      <Editor value={value} onChange={onChange} />
+      <Editor value={currentValue} onChange={setCurrentValue} />
+      <Box sx={{ textAlign: "right", mt: 1 }}>
+        <Button
+          startIcon={<Save />}
+          variant="contained"
+          onClick={() => onSaveButtonClick(currentValue)}
+          disabled={value === currentValue}
+        >
+          保存
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/options/components/CustomContainerParent.tsx
+++ b/src/options/components/CustomContainerParent.tsx
@@ -1,43 +1,22 @@
-import { Box, Typography, InputLabel } from "@mui/material";
-import grey from "@mui/material/colors/grey";
+import { InputLabel, Stack, FormHelperText } from "@mui/material";
 import React from "react";
 
 type Props = {
   label: string;
   caption: string;
-  id?: string;
+  htmlFor: string;
+  optionId?: string;
   children: React.ReactNode;
 };
+
 export const CustomContainerParent = (props: Props) => {
-  const { label, caption, id = "", children } = props;
+  const { label, caption, htmlFor, children } = props;
+
   return (
-    <Box borderBottom="1px solid #ccc" paddingBottom={2} marginTop={2.5}>
-      <Box display="flex" alignItems="flex-end" gap={1}>
-        <InputLabel sx={{ color: grey[700] }}>{label}</InputLabel>
-        <Typography variant="caption" color={grey[500]}>
-          {id}
-        </Typography>
-      </Box>
-      <Box ml={0.1}>
-        <Typography variant="caption">
-          {/* 日本語だったらスペースで改行 */}
-          {chrome.i18n.getUILanguage() === "ja" ? (
-            caption
-              .replace(/\s+/g, " ")
-              .split(" ")
-              .map((text, index) => (
-                <Typography key={index} variant="body2" color={grey[700]} display="block">
-                  {text}
-                </Typography>
-              ))
-          ) : (
-            <Typography variant="body2" color={grey[700]} display="block">
-              {caption}
-            </Typography>
-          )}
-        </Typography>
-      </Box>
+    <Stack gap={1} py={2} borderBottom="1px solid #ccc">
+      <InputLabel htmlFor={htmlFor}>{label}</InputLabel>
+      <FormHelperText>{caption}</FormHelperText>
       {children}
-    </Box>
+    </Stack>
   );
 };

--- a/src/options/components/CustomContainerParent.tsx
+++ b/src/options/components/CustomContainerParent.tsx
@@ -4,7 +4,7 @@ import React from "react";
 type Props = {
   label: string;
   caption: string;
-  htmlFor: string;
+  htmlFor?: string;
   optionId?: string;
   children: React.ReactNode;
 };

--- a/src/options/components/CustomContainerParent.tsx
+++ b/src/options/components/CustomContainerParent.tsx
@@ -1,4 +1,4 @@
-import { InputLabel, Stack, FormHelperText } from "@mui/material";
+import { InputLabel, Stack, FormHelperText, Typography } from "@mui/material";
 import React from "react";
 
 type Props = {
@@ -10,11 +10,16 @@ type Props = {
 };
 
 export const CustomContainerParent = (props: Props) => {
-  const { label, caption, htmlFor, children } = props;
+  const { label, caption, htmlFor, optionId, children } = props;
 
   return (
     <Stack gap={1} py={2} borderBottom="1px solid #ccc">
-      <InputLabel htmlFor={htmlFor}>{label}</InputLabel>
+      <Stack sx={{ flexDirection: "row", alignItems: "flex-end", gap: 1 }}>
+        <InputLabel htmlFor={htmlFor}>{label}</InputLabel>
+        <Typography variant="caption" color="grey.500">
+          {optionId}
+        </Typography>
+      </Stack>
       <FormHelperText>{caption}</FormHelperText>
       {children}
     </Stack>

--- a/src/options/components/CustomRemovableList.tsx
+++ b/src/options/components/CustomRemovableList.tsx
@@ -16,8 +16,8 @@ import { MdDelete } from "react-icons/md";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
-  label: string;
-  caption: string;
+  i18nLabel: string;
+  i18nCaption: string;
   optionId?: string;
   options: string[];
   onChange: (removedIndex: number) => void;
@@ -25,10 +25,15 @@ type Props = {
 };
 
 export const CustomRemovableList = (props: Props) => {
-  const { label, caption, optionId = "", options, onChange, reset } = props;
+  const { i18nLabel, i18nCaption, optionId = "", options, onChange, reset } = props;
   const id = useId();
   return (
-    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
+    <CustomContainerParent
+      label={chrome.i18n.getMessage(i18nLabel) || i18nLabel}
+      caption={chrome.i18n.getMessage(i18nCaption) || i18nCaption}
+      optionId={optionId}
+      htmlFor={id}
+    >
       <Box display="flex" gap={1} flexDirection="column" width={450}>
         <Box display="flex" width="100%" justifyContent="flex-end">
           <Button

--- a/src/options/components/CustomRemovableList.tsx
+++ b/src/options/components/CustomRemovableList.tsx
@@ -11,23 +11,24 @@ import {
   TableContainer,
   Button,
 } from "@mui/material";
-import React from "react";
+import React, { useId } from "react";
 import { MdDelete } from "react-icons/md";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
   label: string;
   caption: string;
-  id?: string;
+  optionId?: string;
   options: string[];
   onChange: (removedIndex: number) => void;
   reset: () => void;
 };
 
 export const CustomRemovableList = (props: Props) => {
-  const { label, caption, id = "", options, onChange, reset } = props;
+  const { label, caption, optionId = "", options, onChange, reset } = props;
+  const id = useId();
   return (
-    <CustomContainerParent label={label} caption={caption} id={id}>
+    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
       <Box display="flex" gap={1} flexDirection="column" width={450}>
         <Box display="flex" width="100%" justifyContent="flex-end">
           <Button

--- a/src/options/components/CustomSelect.tsx
+++ b/src/options/components/CustomSelect.tsx
@@ -10,8 +10,8 @@ type SelectOption = {
 };
 
 type Props = {
-  label: string;
-  caption: string;
+  i18nLabel: string;
+  i18nCaption: string;
   optionId?: string;
   options: SelectOption[];
   value: string | null;
@@ -19,11 +19,16 @@ type Props = {
 };
 
 export const CustomSelect = (props: Props) => {
-  const { label, caption, optionId = "", options, value, onChange } = props;
+  const { i18nLabel, i18nCaption, optionId = "", options, value, onChange } = props;
   const id = useId();
 
   return (
-    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
+    <CustomContainerParent
+      label={chrome.i18n.getMessage(i18nLabel) || i18nLabel}
+      caption={chrome.i18n.getMessage(i18nCaption) || i18nCaption}
+      optionId={optionId}
+      htmlFor={id}
+    >
       <Select
         variant="outlined"
         size="small"

--- a/src/options/components/CustomSelect.tsx
+++ b/src/options/components/CustomSelect.tsx
@@ -1,6 +1,6 @@
 import { Select, MenuItem } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material";
-import React from "react";
+import React, { useId } from "react";
 import type { ReactNode } from "react";
 import { CustomContainerParent } from "./CustomContainerParent";
 
@@ -12,17 +12,26 @@ type SelectOption = {
 type Props = {
   label: string;
   caption: string;
-  id?: string;
+  optionId?: string;
   options: SelectOption[];
   value: string | null;
   onChange: (event: SelectChangeEvent<string>, child: ReactNode) => void;
 };
 
 export const CustomSelect = (props: Props) => {
-  const { label, caption, id = "", options, value, onChange } = props;
+  const { label, caption, optionId = "", options, value, onChange } = props;
+  const id = useId();
+
   return (
-    <CustomContainerParent label={label} caption={caption} id={id}>
-      <Select variant="outlined" size="small" sx={{ width: 450 }} value={value || "unselected"} onChange={onChange}>
+    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
+      <Select
+        variant="outlined"
+        size="small"
+        sx={{ width: 450 }}
+        value={value || "unselected"}
+        onChange={onChange}
+        id={id}
+      >
         {(value === null || value === undefined) && (
           <MenuItem key="none" value="unselected" disabled>
             <em>{chrome.i18n.getMessage("notSelected")}</em>

--- a/src/options/components/CustomSwitch.tsx
+++ b/src/options/components/CustomSwitch.tsx
@@ -4,19 +4,24 @@ import type { ChangeEvent } from "react";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
-  label: string;
-  caption: string;
+  i18nLabel: string;
+  i18nCaption: string;
   optionId?: string;
   value: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>, checked: boolean) => void;
 };
 
 export const CustomSwitch = (props: Props) => {
-  const { label, caption, optionId = "", value, onChange } = props;
+  const { i18nLabel, i18nCaption, optionId = "", value, onChange } = props;
   const id = useId();
 
   return (
-    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
+    <CustomContainerParent
+      label={chrome.i18n.getMessage(i18nLabel) || i18nLabel}
+      caption={chrome.i18n.getMessage(i18nCaption) || i18nCaption}
+      optionId={optionId}
+      htmlFor={id}
+    >
       <Switch checked={value} onChange={onChange} id={id} />
     </CustomContainerParent>
   );

--- a/src/options/components/CustomSwitch.tsx
+++ b/src/options/components/CustomSwitch.tsx
@@ -1,20 +1,23 @@
 import { Switch } from "@mui/material";
-import React from "react";
+import React, { useId } from "react";
 import type { ChangeEvent } from "react";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
   label: string;
   caption: string;
-  id?: string;
+  optionId?: string;
   value: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>, checked: boolean) => void;
 };
+
 export const CustomSwitch = (props: Props) => {
-  const { label, caption, id = "", value, onChange } = props;
+  const { label, caption, optionId = "", value, onChange } = props;
+  const id = useId();
+
   return (
-    <CustomContainerParent label={label} caption={caption} id={id}>
-      <Switch checked={value} onChange={onChange} />
+    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
+      <Switch checked={value} onChange={onChange} id={id} />
     </CustomContainerParent>
   );
 };

--- a/src/options/components/CustomTextField.tsx
+++ b/src/options/components/CustomTextField.tsx
@@ -1,12 +1,11 @@
-import { Box, TextField, IconButton } from "@mui/material";
-import { useId, useState } from "react";
+import { TextField } from "@mui/material";
+import { useId } from "react";
 import type { ChangeEvent } from "react";
-import { MdVisibility, MdVisibilityOff } from "react-icons/md";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
-  label: string;
-  caption: string;
+  i18nLabel: string;
+  i18nCaption: string;
   optionId?: string;
   type?: string;
   value: string;
@@ -14,34 +13,26 @@ type Props = {
 };
 
 export const CustomTextField = (props: Props) => {
-  const { label, caption, optionId = "", value, onChange } = props;
-  const [showPassword, setShowPassword] = useState(false);
-
-  const width = 450;
+  const { i18nLabel, i18nCaption, optionId = "", value, type, onChange } = props;
 
   const id = useId();
-  console.log([label, id]);
-
-  const toggleShowPassword = () => {
-    setShowPassword((show) => !show);
-  };
 
   return (
-    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
-      <Box position="relative" sx={{ width }}>
-        <TextField
-          variant="outlined"
-          size="small"
-          value={value}
-          onChange={onChange}
-          sx={{ width }}
-          type={showPassword ? "text" : "password"}
-          id={id}
-        />
-        <IconButton onClick={toggleShowPassword} sx={{ position: "absolute", right: 0, top: 0 }}>
-          {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
-        </IconButton>
-      </Box>
+    <CustomContainerParent
+      label={chrome.i18n.getMessage(i18nLabel) || i18nLabel}
+      caption={chrome.i18n.getMessage(i18nCaption) || i18nCaption}
+      optionId={optionId}
+      htmlFor={id}
+    >
+      <TextField
+        variant="outlined"
+        size="small"
+        value={value}
+        onChange={onChange}
+        sx={{ width: 450 }}
+        type={type}
+        id={id}
+      />
     </CustomContainerParent>
   );
 };

--- a/src/options/components/CustomTextField.tsx
+++ b/src/options/components/CustomTextField.tsx
@@ -1,6 +1,6 @@
-import { TextField } from "@mui/material";
-import { useId } from "react";
-import type { ChangeEvent } from "react";
+import { Save } from "@mui/icons-material";
+import { Button, Stack, TextField } from "@mui/material";
+import { useId, useState } from "react";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
@@ -9,12 +9,13 @@ type Props = {
   optionId?: string;
   type?: string;
   value: string;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSaveButtonClick: (value: string) => void;
 };
 
 export const CustomTextField = (props: Props) => {
-  const { i18nLabel, i18nCaption, optionId = "", value, type, onChange } = props;
+  const { i18nLabel, i18nCaption, optionId = "", value, type, onSaveButtonClick } = props;
 
+  const [currentValue, setCurrentValue] = useState(value);
   const id = useId();
 
   return (
@@ -24,15 +25,25 @@ export const CustomTextField = (props: Props) => {
       optionId={optionId}
       htmlFor={id}
     >
-      <TextField
-        variant="outlined"
-        size="small"
-        value={value}
-        onChange={onChange}
-        sx={{ width: 450 }}
-        type={type}
-        id={id}
-      />
+      <Stack direction="row" gap={1}>
+        <TextField
+          variant="outlined"
+          size="small"
+          value={currentValue}
+          onChange={(e) => setCurrentValue(e.target.value)}
+          sx={{ width: 450 }}
+          type={type}
+          id={id}
+        />
+        <Button
+          startIcon={<Save />}
+          variant="contained"
+          onClick={() => onSaveButtonClick(currentValue)}
+          disabled={value === currentValue}
+        >
+          保存
+        </Button>
+      </Stack>
     </CustomContainerParent>
   );
 };

--- a/src/options/components/CustomTextField.tsx
+++ b/src/options/components/CustomTextField.tsx
@@ -1,5 +1,5 @@
 import { Box, TextField, IconButton } from "@mui/material";
-import { useState } from "react";
+import { useId, useState } from "react";
 import type { ChangeEvent } from "react";
 import { MdVisibility, MdVisibilityOff } from "react-icons/md";
 import { CustomContainerParent } from "./CustomContainerParent";
@@ -7,42 +7,40 @@ import { CustomContainerParent } from "./CustomContainerParent";
 type Props = {
   label: string;
   caption: string;
-  id?: string;
+  optionId?: string;
   type?: string;
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 export const CustomTextField = (props: Props) => {
-  const { label, caption, id = "", value, onChange, type = "text" } = props;
+  const { label, caption, optionId = "", value, onChange } = props;
   const [showPassword, setShowPassword] = useState(false);
 
   const width = 450;
+
+  const id = useId();
+  console.log([label, id]);
 
   const toggleShowPassword = () => {
     setShowPassword((show) => !show);
   };
 
   return (
-    <CustomContainerParent label={label} caption={caption} id={id}>
+    <CustomContainerParent label={label} caption={caption} optionId={optionId} htmlFor={id}>
       <Box position="relative" sx={{ width }}>
-        {type === "password" ? (
-          <>
-            <TextField
-              variant="outlined"
-              size="small"
-              value={value}
-              onChange={onChange}
-              sx={{ width }}
-              type={showPassword ? "text" : "password"}
-            />
-            <IconButton onClick={toggleShowPassword} sx={{ position: "absolute", right: 0, top: 0 }}>
-              {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
-            </IconButton>
-          </>
-        ) : (
-          <TextField variant="outlined" size="small" value={value} onChange={onChange} sx={{ width }} type={type} />
-        )}
+        <TextField
+          variant="outlined"
+          size="small"
+          value={value}
+          onChange={onChange}
+          sx={{ width }}
+          type={showPassword ? "text" : "password"}
+          id={id}
+        />
+        <IconButton onClick={toggleShowPassword} sx={{ position: "absolute", right: 0, top: 0 }}>
+          {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
+        </IconButton>
       </Box>
     </CustomContainerParent>
   );

--- a/src/options/components/DataOperation.tsx
+++ b/src/options/components/DataOperation.tsx
@@ -166,7 +166,7 @@ export const DataOperation = (props: Props) => {
       <Box>
         <Typography variant="h6" onClick={() => setIsLegacyOpen(!isLegacyOpen)} sx={{ cursor: "pointer" }}>
           <IconButton>{isLegacyOpen ? <MdKeyboardArrowUp /> : <MdKeyboardArrowDown />}</IconButton>
-          ScombZ Utilities v4.0.0未満のデータ移行
+          ScombZ Utilities v4.0.0未満からのデータ移行
         </Typography>
         <Collapse in={isLegacyOpen}>
           <Box mx={5}>

--- a/src/options/components/OptionGroup.tsx
+++ b/src/options/components/OptionGroup.tsx
@@ -1,16 +1,16 @@
 import { Box, Typography } from "@mui/material";
 
 type Props = {
-  title: string;
+  i18nTitle: string;
   description?: string;
   children: React.ReactNode;
 };
 
 export const OptionGroup = (props: Props) => {
-  const { title, description, children } = props;
+  const { i18nTitle, description, children } = props;
   return (
     <Box sx={{ my: 3 }}>
-      <Typography variant="h6">{title}</Typography>
+      <Typography variant="h6">{chrome.i18n.getMessage(i18nTitle) || i18nTitle}</Typography>
       <Typography variant="body1">{description}</Typography>
       <Box sx={{ display: "felx", flexDirection: "column", gap: 1 }}>{children}</Box>
     </Box>

--- a/src/options/components/OptionGroup.tsx
+++ b/src/options/components/OptionGroup.tsx
@@ -9,10 +9,10 @@ type Props = {
 export const OptionGroup = (props: Props) => {
   const { title, description, children } = props;
   return (
-    <Box sx={{ px: 1, my: 3 }}>
+    <Box sx={{ my: 3 }}>
       <Typography variant="h6">{title}</Typography>
       <Typography variant="body1">{description}</Typography>
-      <Box sx={{ display: "felx", flexDirection: "column", gap: 1, px: 1 }}>{children}</Box>
+      <Box sx={{ display: "felx", flexDirection: "column", gap: 1 }}>{children}</Box>
     </Box>
   );
 };

--- a/src/options/components/RecommendedOptions.tsx
+++ b/src/options/components/RecommendedOptions.tsx
@@ -66,8 +66,8 @@ export const RecommendedOptions = (props: Props) => {
             i18nCaption="optionDescriptionStudentID"
             optionId="loginData.username"
             value={saves.settings.loginData.username.split("@")[0]}
-            onChange={(e) => {
-              const username = e.target.value.includes("@") ? e.target.value : e.target.value + "@sic";
+            onSaveButtonClick={(value) => {
+              const username = value.includes("@") ? value : value + "@sic";
               setSettings("loginData", { ...saves.settings.loginData, username });
             }}
           />
@@ -77,9 +77,7 @@ export const RecommendedOptions = (props: Props) => {
             i18nCaption="optionDescriptionPassword"
             optionId="loginData.password"
             value={saves.settings.loginData.password}
-            onChange={(_event) =>
-              setSettings("loginData", { ...saves.settings.loginData, password: _event.target.value })
-            }
+            onSaveButtonClick={(value) => setSettings("loginData", { ...saves.settings.loginData, password: value })}
           />
         </OptionGroup>
 

--- a/src/options/components/RecommendedOptions.tsx
+++ b/src/options/components/RecommendedOptions.tsx
@@ -34,11 +34,11 @@ export const RecommendedOptions = (props: Props) => {
     <Box>
       <Typography variant="h5">{chrome.i18n.getMessage("RecommendedOptions")}</Typography>
       <Stack gap={1} py={1}>
-        <OptionGroup title={chrome.i18n.getMessage("OptionGroupSyllabusLinking")}>
+        <OptionGroup i18nTitle="OptionGroupSyllabusLinking">
           <CustomSelect
-            label={chrome.i18n.getMessage("optionTitleFaculty")}
+            i18nLabel="optionTitleFaculty"
             optionId="faculty"
-            caption={chrome.i18n.getMessage("optionDescriptionFaculty")}
+            i18nCaption="optionDescriptionFaculty"
             options={
               chrome.i18n.getUILanguage() === "ja"
                 ? [
@@ -60,10 +60,10 @@ export const RecommendedOptions = (props: Props) => {
             onChange={(e, _) => setSettings("faculty", e.target.value)}
           />
         </OptionGroup>
-        <OptionGroup title={chrome.i18n.getMessage("OptionGroupAutomaticLogin")}>
+        <OptionGroup i18nTitle="OptionGroupAutomaticLogin">
           <CustomTextField
-            label={chrome.i18n.getMessage("optionTitleStudentID")}
-            caption={chrome.i18n.getMessage("optionDescriptionStudentID")}
+            i18nLabel="optionTitleStudentID"
+            i18nCaption="optionDescriptionStudentID"
             optionId="loginData.username"
             value={saves.settings.loginData.username.split("@")[0]}
             onChange={(e) => {
@@ -72,9 +72,9 @@ export const RecommendedOptions = (props: Props) => {
             }}
           />
           <CustomTextField
-            label={chrome.i18n.getMessage("optionTitlePassword")}
+            i18nLabel="optionTitlePassword"
             type="password"
-            caption={chrome.i18n.getMessage("optionDescriptionPassword")}
+            i18nCaption="optionDescriptionPassword"
             optionId="loginData.password"
             value={saves.settings.loginData.password}
             onChange={(_event) =>
@@ -83,12 +83,12 @@ export const RecommendedOptions = (props: Props) => {
           />
         </OptionGroup>
 
-        <OptionGroup title={chrome.i18n.getMessage("OptionGroupWidget")}>
+        <OptionGroup i18nTitle="OptionGroupWidget">
           <CustomWidgetSort saves={saves} setSettings={setSettings} />
           <CustomRemovableList
-            label={chrome.i18n.getMessage("optionTitleHiddenTaskList")}
+            i18nLabel="optionTitleHiddenTaskList"
             optionId="hiddenTaskIdList"
-            caption={chrome.i18n.getMessage("optionDescriptionHiddenTaskList")}
+            i18nCaption="optionDescriptionHiddenTaskList"
             options={hiddenTaskList}
             onChange={(idx) => {
               const newIds = saves.settings.hiddenTaskIdList.filter((_, i) => i !== idx);
@@ -97,15 +97,15 @@ export const RecommendedOptions = (props: Props) => {
             reset={() => setSettings("hiddenTaskIdList", [])}
           />
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleDisplayClassroom")}
-            caption={chrome.i18n.getMessage("optionDescriptionDisplayClassroom")}
+            i18nLabel="optionTitleDisplayClassroom"
+            i18nCaption="optionDescriptionDisplayClassroom"
             optionId="displayClassroom"
             value={saves.settings.displayClassroom}
             onChange={(_e, checked) => setSettings("displayClassroom", checked)}
           />
           <CustomSelect
-            label={chrome.i18n.getMessage("optionTitleTimeTableTopDate")}
-            caption={chrome.i18n.getMessage("optionDescriptionTimeTableTopDate")}
+            i18nLabel="optionTitleTimeTableTopDate"
+            i18nCaption="optionDescriptionTimeTableTopDate"
             optionId="timeTableTopDate"
             value={saves.settings.timeTableTopDate.toString()}
             options={[
@@ -117,73 +117,73 @@ export const RecommendedOptions = (props: Props) => {
           />
         </OptionGroup>
 
-        <OptionGroup title="LMS">
+        <OptionGroup i18nTitle="LMS">
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleLmsShowClassroom")}
-            caption={chrome.i18n.getMessage("optionDescriptionLmsShowClassroom")}
+            i18nLabel="optionTitleLmsShowClassroom"
+            i18nCaption="optionDescriptionLmsShowClassroom"
             optionId="lms.showClassroom"
             value={saves.settings.lms.showClassroom}
             onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, showClassroom: checked })}
           />
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleLmsHideNoClassDay")}
-            caption={chrome.i18n.getMessage("optionDescriptionLmsHideNoClassDay")}
+            i18nLabel="optionTitleLmsHideNoClassDay"
+            i18nCaption="optionDescriptionLmsHideNoClassDay"
             optionId="lms.hideNoClassDay"
             value={saves.settings.lms.hideNoClassDay}
             onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, hideNoClassDay: checked })}
           />
         </OptionGroup>
 
-        <OptionGroup title={chrome.i18n.getMessage("OptionGroupCoursePage")}>
+        <OptionGroup i18nTitle="OptionGroupCoursePage">
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleDownloadFileBundle")}
-            caption={chrome.i18n.getMessage("optionDescriptionDownloadFileBundle")}
+            i18nLabel="optionTitleDownloadFileBundle"
+            i18nCaption="optionDescriptionDownloadFileBundle"
             optionId="downloadFileBundle"
             value={saves.settings.downloadFileBundle}
             onChange={(_e, checked) => setSettings("downloadFileBundle", checked)}
           />
 
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleLayoutLinkify")}
-            caption={chrome.i18n.getMessage("optionDescriptionLayoutLinkify")}
+            i18nLabel="optionTitleLayoutLinkify"
+            i18nCaption="optionDescriptionLayoutLinkify"
             optionId="layout.linkify"
             value={saves.settings.layout.linkify}
             onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, linkify: checked })}
           />
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleMarkdownNotePad")}
-            caption={chrome.i18n.getMessage("optionDescriptionMarkdownNotePad")}
+            i18nLabel="optionTitleMarkdownNotePad"
+            i18nCaption="optionDescriptionMarkdownNotePad"
             optionId="markdownNotePad"
             value={saves.settings.markdownNotePad}
             onChange={(_e, checked) => setSettings("markdownNotePad", checked)}
           />
         </OptionGroup>
 
-        <OptionGroup title={chrome.i18n.getMessage("OptionGroupOthers")}>
+        <OptionGroup i18nTitle="OptionGroupOthers">
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleModifyClickableLinks")}
-            caption={chrome.i18n.getMessage("optionDescriptionModifyClickableLinks")}
+            i18nLabel="optionTitleModifyClickableLinks"
+            i18nCaption="optionDescriptionModifyClickableLinks"
             optionId="modifyClickableLinks"
             value={saves.settings.modifyClickableLinks}
             onChange={(_e, checked) => setSettings("modifyClickableLinks", checked)}
           />
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleForceDragAndDropSubmit")}
-            caption={chrome.i18n.getMessage("optionDescriptionForceDragAndDropSubmit")}
+            i18nLabel="optionTitleForceDragAndDropSubmit"
+            i18nCaption="optionDescriptionForceDragAndDropSubmit"
             optionId="forceDragAndDropSubmit"
             value={saves.settings.forceDragAndDropSubmit}
             onChange={(_e, checked) => setSettings("forceDragAndDropSubmit", checked)}
           />
           <CustomSwitch
-            label={chrome.i18n.getMessage("optionTitleLayoutClickToHideName")}
-            caption={chrome.i18n.getMessage("optionDescriptionLayoutClickToHideName")}
+            i18nLabel="optionTitleLayoutClickToHideName"
+            i18nCaption="optionDescriptionLayoutClickToHideName"
             optionId="layout.clickToHideName"
             value={saves.settings.layout.clickToHideName}
             onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, clickToHideName: checked })}
           />
           <CustomSelect
-            label={chrome.i18n.getMessage("optionTitleHeadLinkTo")}
-            caption={chrome.i18n.getMessage("optionDescriptionHeadLinkTo")}
+            i18nLabel="optionTitleHeadLinkTo"
+            i18nCaption="optionDescriptionHeadLinkTo"
             optionId="headLinkTo"
             options={[
               { value: "/portal/home", label: "ホーム / Top" },

--- a/src/options/components/RecommendedOptions.tsx
+++ b/src/options/components/RecommendedOptions.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { useMemo } from "react";
 import { CustomRemovableList } from "./CustomRemovableList";
 import { CustomSelect } from "./CustomSelect";
@@ -29,14 +29,15 @@ export const RecommendedOptions = (props: Props) => {
     saves.scombzData.originalTasklist,
     saves.settings.hiddenTaskIdList,
   ]);
+
   return (
     <Box>
       <Typography variant="h5">{chrome.i18n.getMessage("RecommendedOptions")}</Typography>
-      <Box display="flex" flexDirection="column" gap={1} p={1}>
+      <Stack gap={1} py={1}>
         <OptionGroup title={chrome.i18n.getMessage("OptionGroupSyllabusLinking")}>
           <CustomSelect
             label={chrome.i18n.getMessage("optionTitleFaculty")}
-            id="faculty"
+            optionId="faculty"
             caption={chrome.i18n.getMessage("optionDescriptionFaculty")}
             options={
               chrome.i18n.getUILanguage() === "ja"
@@ -63,7 +64,7 @@ export const RecommendedOptions = (props: Props) => {
           <CustomTextField
             label={chrome.i18n.getMessage("optionTitleStudentID")}
             caption={chrome.i18n.getMessage("optionDescriptionStudentID")}
-            id="loginData.username"
+            optionId="loginData.username"
             value={saves.settings.loginData.username.split("@")[0]}
             onChange={(e) => {
               const username = e.target.value.includes("@") ? e.target.value : e.target.value + "@sic";
@@ -74,7 +75,7 @@ export const RecommendedOptions = (props: Props) => {
             label={chrome.i18n.getMessage("optionTitlePassword")}
             type="password"
             caption={chrome.i18n.getMessage("optionDescriptionPassword")}
-            id="loginData.password"
+            optionId="loginData.password"
             value={saves.settings.loginData.password}
             onChange={(_event) =>
               setSettings("loginData", { ...saves.settings.loginData, password: _event.target.value })
@@ -86,7 +87,7 @@ export const RecommendedOptions = (props: Props) => {
           <CustomWidgetSort saves={saves} setSettings={setSettings} />
           <CustomRemovableList
             label={chrome.i18n.getMessage("optionTitleHiddenTaskList")}
-            id="hiddenTaskIdList"
+            optionId="hiddenTaskIdList"
             caption={chrome.i18n.getMessage("optionDescriptionHiddenTaskList")}
             options={hiddenTaskList}
             onChange={(idx) => {
@@ -98,14 +99,14 @@ export const RecommendedOptions = (props: Props) => {
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleDisplayClassroom")}
             caption={chrome.i18n.getMessage("optionDescriptionDisplayClassroom")}
-            id="displayClassroom"
+            optionId="displayClassroom"
             value={saves.settings.displayClassroom}
             onChange={(_e, checked) => setSettings("displayClassroom", checked)}
           />
           <CustomSelect
             label={chrome.i18n.getMessage("optionTitleTimeTableTopDate")}
             caption={chrome.i18n.getMessage("optionDescriptionTimeTableTopDate")}
-            id="timeTableTopDate"
+            optionId="timeTableTopDate"
             value={saves.settings.timeTableTopDate.toString()}
             options={[
               { value: "date", label: "日付 / Date" },
@@ -120,14 +121,14 @@ export const RecommendedOptions = (props: Props) => {
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleLmsShowClassroom")}
             caption={chrome.i18n.getMessage("optionDescriptionLmsShowClassroom")}
-            id="lms.showClassroom"
+            optionId="lms.showClassroom"
             value={saves.settings.lms.showClassroom}
             onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, showClassroom: checked })}
           />
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleLmsHideNoClassDay")}
             caption={chrome.i18n.getMessage("optionDescriptionLmsHideNoClassDay")}
-            id="lms.hideNoClassDay"
+            optionId="lms.hideNoClassDay"
             value={saves.settings.lms.hideNoClassDay}
             onChange={(_e, checked) => setSettings("lms", { ...saves.settings.lms, hideNoClassDay: checked })}
           />
@@ -137,7 +138,7 @@ export const RecommendedOptions = (props: Props) => {
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleDownloadFileBundle")}
             caption={chrome.i18n.getMessage("optionDescriptionDownloadFileBundle")}
-            id="downloadFileBundle"
+            optionId="downloadFileBundle"
             value={saves.settings.downloadFileBundle}
             onChange={(_e, checked) => setSettings("downloadFileBundle", checked)}
           />
@@ -145,14 +146,14 @@ export const RecommendedOptions = (props: Props) => {
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleLayoutLinkify")}
             caption={chrome.i18n.getMessage("optionDescriptionLayoutLinkify")}
-            id="layout.linkify"
+            optionId="layout.linkify"
             value={saves.settings.layout.linkify}
             onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, linkify: checked })}
           />
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleMarkdownNotePad")}
             caption={chrome.i18n.getMessage("optionDescriptionMarkdownNotePad")}
-            id="markdownNotePad"
+            optionId="markdownNotePad"
             value={saves.settings.markdownNotePad}
             onChange={(_e, checked) => setSettings("markdownNotePad", checked)}
           />
@@ -162,28 +163,28 @@ export const RecommendedOptions = (props: Props) => {
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleModifyClickableLinks")}
             caption={chrome.i18n.getMessage("optionDescriptionModifyClickableLinks")}
-            id="modifyClickableLinks"
+            optionId="modifyClickableLinks"
             value={saves.settings.modifyClickableLinks}
             onChange={(_e, checked) => setSettings("modifyClickableLinks", checked)}
           />
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleForceDragAndDropSubmit")}
             caption={chrome.i18n.getMessage("optionDescriptionForceDragAndDropSubmit")}
-            id="forceDragAndDropSubmit"
+            optionId="forceDragAndDropSubmit"
             value={saves.settings.forceDragAndDropSubmit}
             onChange={(_e, checked) => setSettings("forceDragAndDropSubmit", checked)}
           />
           <CustomSwitch
             label={chrome.i18n.getMessage("optionTitleLayoutClickToHideName")}
             caption={chrome.i18n.getMessage("optionDescriptionLayoutClickToHideName")}
-            id="layout.clickToHideName"
+            optionId="layout.clickToHideName"
             value={saves.settings.layout.clickToHideName}
             onChange={(_e, checked) => setSettings("layout", { ...saves.settings.layout, clickToHideName: checked })}
           />
           <CustomSelect
             label={chrome.i18n.getMessage("optionTitleHeadLinkTo")}
             caption={chrome.i18n.getMessage("optionDescriptionHeadLinkTo")}
-            id="headLinkTo"
+            optionId="headLinkTo"
             options={[
               { value: "/portal/home", label: "ホーム / Top" },
               { value: "/lms/timetable", label: "LMS" },
@@ -193,7 +194,7 @@ export const RecommendedOptions = (props: Props) => {
             onChange={(e, _) => setSettings("headLinkTo", e.target.value)}
           />
         </OptionGroup>
-      </Box>
+      </Stack>
     </Box>
   );
 };

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -210,24 +210,24 @@ export const WidgetOptions = (props: Props) => {
         <Box mb={8}>
           <Typography variant="h6">ウィジェット基本設定</Typography>
           <CustomSwitch
-            label="時間割表示"
-            caption={`サイドメニュー展開時に、右のスペースに簡易的な時間割を表示します。
+            i18nLabel="時間割表示"
+            i18nCaption={`サイドメニュー展開時に、右のスペースに簡易的な時間割を表示します。
                       この時間割はLMS以外の画面でも展開できるため、科目ページに直接アクセスできます。`}
             id="useSubTimeTable"
             value={saves.settings.useSubTimeTable}
             onChange={(_e, checked) => setSettings("useSubTimeTable", checked)}
           />
           <CustomSwitch
-            label="課題表示"
-            caption={`サイドメニュー展開時に、右のスペースに課題一覧を表示します。
+            i18nLabel="課題表示"
+            i18nCaption={`サイドメニュー展開時に、右のスペースに課題一覧を表示します。
                       表示される課題一覧は約15分ごとに更新されます。`}
             id="useTaskList"
             value={saves.settings.useTaskList}
             onChange={(_e, checked) => setSettings("useTaskList", checked)}
           />
           <CustomSwitch
-            label="2カラムレイアウトを有効化"
-            caption={`並び替え可能なウィジェットを2列に並べて表示します。`}
+            i18nLabel="2カラムレイアウトを有効化"
+            i18nCaption={`並び替え可能なウィジェットを2列に並べて表示します。`}
             id="columnCount"
             value={saves.settings.columnCount === 2}
             onChange={(_e, checked) => setSettings("columnCount", checked ? 2 : 1)}
@@ -237,24 +237,24 @@ export const WidgetOptions = (props: Props) => {
         <Box my={1}>
           <Typography variant="h6">ウィジェット詳細設定</Typography>
           <CustomSwitch
-            label="時間割 教室表示"
-            caption={`メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。
+            i18nLabel="時間割 教室表示"
+            i18nCaption={`メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。
                         なお、日別表示の際はこの項目にかかわらず教室情報が表示されます。`}
             id="displayClassroom"
             value={saves.settings.displayClassroom}
             onChange={(_e, checked) => setSettings("displayClassroom", checked)}
           />
           <CustomSwitch
-            label="時間割 授業時間表示"
-            caption={`メニュー横ウィジェットの時間割に、各時限の開始及び終了時刻を表示します。
+            i18nLabel="時間割 授業時間表示"
+            i18nCaption={`メニュー横ウィジェットの時間割に、各時限の開始及び終了時刻を表示します。
                         なお、日別表示の際はこの項目にかかわらず時限情報が表示されます。`}
             id="displayTime"
             value={saves.settings.displayTime}
             onChange={(_e, checked) => setSettings("displayTime", checked)}
           />
           <CustomSelect
-            label="時間割 今日の日付・時刻表示"
-            caption={`メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。`}
+            i18nLabel="時間割 今日の日付・時刻表示"
+            i18nCaption={`メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。`}
             optionId="timeTableTopDate"
             value={saves.settings.timeTableTopDate.toString()}
             options={[
@@ -265,23 +265,23 @@ export const WidgetOptions = (props: Props) => {
             onChange={(e, _) => setSettings("timeTableTopDate", e.target.value === "false" ? false : e.target.value)}
           />
           <CustomSwitch
-            label="時間割 現在の授業を目立たせる"
-            caption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
+            i18nLabel="時間割 現在の授業を目立たせる"
+            i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
             id="highlightToday"
             value={saves.settings.highlightToday}
             onChange={(_e, checked) => setSettings("highlightToday", checked)}
           />
 
           <CustomSwitch
-            label="課題一覧 残り時間で強調表示"
-            caption={`メニュー横ウィジェットの課題一覧で、提出期限に近いものを色をつけて目立たせます。`}
+            i18nLabel="課題一覧 残り時間で強調表示"
+            i18nCaption={`メニュー横ウィジェットの課題一覧で、提出期限に近いものを色をつけて目立たせます。`}
             id="highlightTask"
             value={saves.settings.highlightTask}
             onChange={(_e, checked) => setSettings("highlightTask", checked)}
           />
           <CustomSelect
-            label="課題一覧 期限表示モード"
-            caption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式を選択します。"
+            i18nLabel="課題一覧 期限表示モード"
+            i18nCaption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式を選択します。"
             options={[
               { value: "relative", label: "相対表示（残り時間）" },
               { value: "absolute", label: "絶対表示（提出期限時刻）" },
@@ -291,23 +291,23 @@ export const WidgetOptions = (props: Props) => {
             onChange={(e, _) => setSettings("deadlineMode", e.target.value)}
           />
           <CustomTextField
-            label="課題一覧 提出期限表示フォーマット"
-            caption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式が絶対表示の時の表示フォーマットを変更します。 yyyy:年 MM:月 E:曜日 dd:日 HH:時 mm:分"
+            i18nLabel="課題一覧 提出期限表示フォーマット"
+            i18nCaption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式が絶対表示の時の表示フォーマットを変更します。 yyyy:年 MM:月 E:曜日 dd:日 HH:時 mm:分"
             id="deadlineFormat"
             value={saves.settings.deadlineFormat}
             onChange={(e) => setSettings("deadlineFormat", e.target.value)}
           />
           <CustomTextField
-            label="課題一覧 表示件数"
+            i18nLabel="課題一覧 表示件数"
             type="number"
-            caption="メニュー横ウィジェットの課題一覧で、1ページ内に表示する課題の最大件数を設定します。 課題の数がこれを超えた場合であっても、ページネーションにより全ての課題を確認できます。"
+            i18nCaption="メニュー横ウィジェットの課題一覧で、1ページ内に表示する課題の最大件数を設定します。 課題の数がこれを超えた場合であっても、ページネーションにより全ての課題を確認できます。"
             id="taskListRowsPerPage"
             value={saves.settings.taskListRowsPerPage.toString()}
             onChange={(e) => setSettings("taskListRowsPerPage", parseInt(e.target.value, 10))}
           />
           <CustomRemovableList
-            label="リンク集 リンク削除"
-            caption="サイドメニューにリンク集を追加できます。リンク集は好きに追加可能です。"
+            i18nLabel="リンク集 リンク削除"
+            i18nCaption="サイドメニューにリンク集を追加できます。リンク集は好きに追加可能です。"
             id="originalLinks"
             options={saves.settings.originalLinks.map((link) => link.title + " - " + link.url)}
             onChange={(idx) => {

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -295,7 +295,7 @@ export const WidgetOptions = (props: Props) => {
             i18nCaption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式が絶対表示の時の表示フォーマットを変更します。 yyyy:年 MM:月 E:曜日 dd:日 HH:時 mm:分"
             optionId="deadlineFormat"
             value={saves.settings.deadlineFormat}
-            onChange={(e) => setSettings("deadlineFormat", e.target.value)}
+            onSaveButtonClick={(value) => setSettings("deadlineFormat", value)}
           />
           <CustomTextField
             i18nLabel="課題一覧 表示件数"
@@ -303,7 +303,7 @@ export const WidgetOptions = (props: Props) => {
             i18nCaption="メニュー横ウィジェットの課題一覧で、1ページ内に表示する課題の最大件数を設定します。 課題の数がこれを超えた場合であっても、ページネーションにより全ての課題を確認できます。"
             optionId="taskListRowsPerPage"
             value={saves.settings.taskListRowsPerPage.toString()}
-            onChange={(e) => setSettings("taskListRowsPerPage", parseInt(e.target.value, 10))}
+            onSaveButtonClick={(value) => setSettings("taskListRowsPerPage", parseInt(value, 10))}
           />
           <CustomRemovableList
             i18nLabel="リンク集 リンク削除"

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -208,7 +208,7 @@ export const WidgetOptions = (props: Props) => {
       </Box>
       <Box display="flex" flexDirection="column" gap={1} p={1}>
         <Box mb={8}>
-          <Typography variant="h6">ウィジェット基本設定</Typography>
+          <Typography variant="h6">基本設定</Typography>
           <CustomSwitch
             i18nLabel="時間割表示"
             i18nCaption={`サイドメニュー展開時に、右のスペースに簡易的な時間割を表示します。
@@ -235,7 +235,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomWidgetSort saves={saves} setSettings={setSettings} />
         </Box>
         <Box my={1}>
-          <Typography variant="h6">ウィジェット詳細設定</Typography>
+          <Typography variant="h6">詳細設定</Typography>
           <CustomSwitch
             i18nLabel="時間割 教室表示"
             i18nCaption={`メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。
@@ -265,7 +265,7 @@ export const WidgetOptions = (props: Props) => {
             onChange={(e, _) => setSettings("timeTableTopDate", e.target.value === "false" ? false : e.target.value)}
           />
           <CustomSwitch
-            i18nLabel="時間割 現在の授業を目立たせる"
+            i18nLabel="時間割 現在の授業を強調表示"
             i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
             optionId="highlightToday"
             value={saves.settings.highlightToday}
@@ -273,7 +273,7 @@ export const WidgetOptions = (props: Props) => {
           />
 
           <CustomSwitch
-            i18nLabel="課題一覧 残り時間で強調表示"
+            i18nLabel="課題一覧 残り時間に応じて強調表示"
             i18nCaption={`メニュー横ウィジェットの課題一覧で、提出期限に近いものを色をつけて目立たせます。`}
             optionId="highlightTask"
             value={saves.settings.highlightTask}

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -255,7 +255,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomSelect
             label="時間割 今日の日付・時刻表示"
             caption={`メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。`}
-            id="timeTableTopDate"
+            optionId="timeTableTopDate"
             value={saves.settings.timeTableTopDate.toString()}
             options={[
               { value: "date", label: "日付" },
@@ -286,7 +286,7 @@ export const WidgetOptions = (props: Props) => {
               { value: "relative", label: "相対表示（残り時間）" },
               { value: "absolute", label: "絶対表示（提出期限時刻）" },
             ]}
-            id="deadlineMode"
+            optionId="deadlineMode"
             value={saves.settings.deadlineMode}
             onChange={(e, _) => setSettings("deadlineMode", e.target.value)}
           />

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -89,7 +89,7 @@ export const CustomWidgetSort = (props: CustomWidgetSortProps) => {
   return (
     <CustomContainerParent
       label={chrome.i18n.getMessage("optionTitleWidgetOrder")}
-      id="widgetOrder"
+      optionId="widgetOrder"
       caption={chrome.i18n.getMessage("optionDescriptionWidgetOrder")}
     >
       <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
@@ -213,7 +213,7 @@ export const WidgetOptions = (props: Props) => {
             i18nLabel="時間割表示"
             i18nCaption={`サイドメニュー展開時に、右のスペースに簡易的な時間割を表示します。
                       この時間割はLMS以外の画面でも展開できるため、科目ページに直接アクセスできます。`}
-            id="useSubTimeTable"
+            optionId="useSubTimeTable"
             value={saves.settings.useSubTimeTable}
             onChange={(_e, checked) => setSettings("useSubTimeTable", checked)}
           />
@@ -221,14 +221,14 @@ export const WidgetOptions = (props: Props) => {
             i18nLabel="課題表示"
             i18nCaption={`サイドメニュー展開時に、右のスペースに課題一覧を表示します。
                       表示される課題一覧は約15分ごとに更新されます。`}
-            id="useTaskList"
+            optionId="useTaskList"
             value={saves.settings.useTaskList}
             onChange={(_e, checked) => setSettings("useTaskList", checked)}
           />
           <CustomSwitch
             i18nLabel="2カラムレイアウトを有効化"
             i18nCaption={`並び替え可能なウィジェットを2列に並べて表示します。`}
-            id="columnCount"
+            optionId="columnCount"
             value={saves.settings.columnCount === 2}
             onChange={(_e, checked) => setSettings("columnCount", checked ? 2 : 1)}
           />
@@ -240,7 +240,7 @@ export const WidgetOptions = (props: Props) => {
             i18nLabel="時間割 教室表示"
             i18nCaption={`メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。
                         なお、日別表示の際はこの項目にかかわらず教室情報が表示されます。`}
-            id="displayClassroom"
+            optionId="displayClassroom"
             value={saves.settings.displayClassroom}
             onChange={(_e, checked) => setSettings("displayClassroom", checked)}
           />
@@ -248,7 +248,7 @@ export const WidgetOptions = (props: Props) => {
             i18nLabel="時間割 授業時間表示"
             i18nCaption={`メニュー横ウィジェットの時間割に、各時限の開始及び終了時刻を表示します。
                         なお、日別表示の際はこの項目にかかわらず時限情報が表示されます。`}
-            id="displayTime"
+            optionId="displayTime"
             value={saves.settings.displayTime}
             onChange={(_e, checked) => setSettings("displayTime", checked)}
           />
@@ -267,7 +267,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomSwitch
             i18nLabel="時間割 現在の授業を目立たせる"
             i18nCaption={`LMSページおよびメニュー横ウィジェットの時間割で、現在の授業時間を目立たせます。`}
-            id="highlightToday"
+            optionId="highlightToday"
             value={saves.settings.highlightToday}
             onChange={(_e, checked) => setSettings("highlightToday", checked)}
           />
@@ -275,7 +275,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomSwitch
             i18nLabel="課題一覧 残り時間で強調表示"
             i18nCaption={`メニュー横ウィジェットの課題一覧で、提出期限に近いものを色をつけて目立たせます。`}
-            id="highlightTask"
+            optionId="highlightTask"
             value={saves.settings.highlightTask}
             onChange={(_e, checked) => setSettings("highlightTask", checked)}
           />
@@ -293,7 +293,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomTextField
             i18nLabel="課題一覧 提出期限表示フォーマット"
             i18nCaption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式が絶対表示の時の表示フォーマットを変更します。 yyyy:年 MM:月 E:曜日 dd:日 HH:時 mm:分"
-            id="deadlineFormat"
+            optionId="deadlineFormat"
             value={saves.settings.deadlineFormat}
             onChange={(e) => setSettings("deadlineFormat", e.target.value)}
           />
@@ -301,14 +301,14 @@ export const WidgetOptions = (props: Props) => {
             i18nLabel="課題一覧 表示件数"
             type="number"
             i18nCaption="メニュー横ウィジェットの課題一覧で、1ページ内に表示する課題の最大件数を設定します。 課題の数がこれを超えた場合であっても、ページネーションにより全ての課題を確認できます。"
-            id="taskListRowsPerPage"
+            optionId="taskListRowsPerPage"
             value={saves.settings.taskListRowsPerPage.toString()}
             onChange={(e) => setSettings("taskListRowsPerPage", parseInt(e.target.value, 10))}
           />
           <CustomRemovableList
             i18nLabel="リンク集 リンク削除"
             i18nCaption="サイドメニューにリンク集を追加できます。リンク集は好きに追加可能です。"
-            id="originalLinks"
+            optionId="originalLinks"
             options={saves.settings.originalLinks.map((link) => link.title + " - " + link.url)}
             onChange={(idx) => {
               const newLinks = saves.settings.originalLinks.filter((_, i) => i !== idx);

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ThemeProvider } from "@mui/material";
+import { Alert, Box, Button, Snackbar, ThemeProvider } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { ComplexOptions } from "./components/ComplexOptions";
 import { SimpleOptions } from "./components/SimpleOptions";
@@ -10,6 +10,7 @@ import "./index.css";
 const OptionsIndex = () => {
   const [isSimple, setIsSimple] = useState<boolean>(true);
   const [currentLocalStorage, setCurrentLocalStorage] = useState<Saves>(defaultSaves);
+  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
 
   const setSettings = async (key: string, value: unknown) => {
     const newLocalStorage = {
@@ -21,6 +22,7 @@ const OptionsIndex = () => {
     };
     setCurrentLocalStorage(newLocalStorage);
     await chrome.storage.local.set(newLocalStorage);
+    setSnackbarOpen(true);
   };
 
   const setScombzData = async (key: string, value: unknown) => {
@@ -43,6 +45,21 @@ const OptionsIndex = () => {
 
   return (
     <ThemeProvider theme={theme}>
+      <Snackbar
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        open={snackbarOpen}
+        autoHideDuration={2000}
+        onClose={() => setSnackbarOpen(false)}
+      >
+        <Alert
+          onClose={() => setSnackbarOpen(false)}
+          severity="success"
+          variant="filled"
+          sx={{ width: "300px", py: 1 }}
+        >
+          設定を保存しました
+        </Alert>
+      </Snackbar>
       <Box p={0} maxWidth={1000} margin="0 auto">
         <Box pt={2} pb={5} mx={0}>
           <Box textAlign="center" mb={2}>

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -51,6 +51,20 @@ const OptionsIndex = () => {
               alt="ScombZ Utilities"
               style={{ width: "50%", maxWidth: "250px", margin: "0 auto", display: "block" }}
             />
+            <Button
+              sx={{
+                backgroundColor: "#fff",
+                "&:hover": {
+                  backgroundColor: "#f4f4f4",
+                },
+              }}
+              variant="outlined"
+              onClick={() => {
+                setIsSimple(!isSimple);
+              }}
+            >
+              {isSimple ? "詳細設定へ" : "かんたん設定へ"}
+            </Button>
           </Box>
 
           {isSimple ? (
@@ -63,43 +77,6 @@ const OptionsIndex = () => {
               setSaves={setCurrentLocalStorage}
             />
           )}
-
-          <Box
-            m={1}
-            position="fixed"
-            sx={{
-              bottom: 0,
-              right: 0,
-              width: "100%",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              backgroundColor: "#fffa",
-              backdropFilter: "blur(3px)",
-              boxShadow: "0 0 6px #0003",
-              margin: 0,
-              padding: 1,
-            }}
-          >
-            <Box position="relative" width="100%" display="flex" alignItems="center" justifyContent="center">
-              <Box position="absolute" left={30} top={0} ml={1}>
-                <Button
-                  sx={{
-                    backgroundColor: "#fff",
-                    "&:hover": {
-                      backgroundColor: "#f4f4f4",
-                    },
-                  }}
-                  variant="outlined"
-                  onClick={() => {
-                    setIsSimple(!isSimple);
-                  }}
-                >
-                  {isSimple ? "詳細設定へ" : "かんたん設定へ"}
-                </Button>
-              </Box>
-            </Box>
-          </Box>
         </Box>
       </Box>
     </ThemeProvider>


### PR DESCRIPTION
既に差分が大きいのでこのPRではここまでで区切ります、すみません......。

## 概要

- 設定の変更が即座に保存されるよう変更（同時にスナックバーを表示）
- 横幅を1000pxに制限し、詳細設定への切り替えボタンを画面上部に移動
- ReactのuseIdフックを使い、すべてのlabelタグにfor属性を付与
- `Custom{Select, Switch, TextField, RemovableList}.tsx`コンポーネントにおける、i18nテキストを取得するための冗長な記述のリファクタ
- 幾つかの設定項目の文言

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

<img width="1470" alt="スクリーンショット 2024-05-14 1 13 06" src="https://github.com/scombz-utilities/scombz-utilities-react/assets/51036153/5f792600-8da6-4cf4-b1ea-5701d72b58a5">


## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [ ] NO

## チェック項目

- [ ] ビルドが通る
- [ ] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
- [ ] 複雑なコードにはコメントを記載してある

### 種別

- optimisation - 既存機能修正・最適化
- style - スタイル変更