### PR TITLE
Fix/layouts

### DIFF
--- a/css/quickmenu.css
+++ b/css/quickmenu.css
@@ -1,21 +1,43 @@
 #quickMenu {
   margin: 40px 70px 0 34px;
   background-color: #fafbfd;
-  padding: 20px 40px;
+  padding: 15px 30px;
   display: flex;
-  gap: 15px;
+  gap: 20px;
   align-items: center;
-  justify-content: start;
+  justify-content: center;
 }
 #quickMenu a {
-  color: #556cd6;
+  color: #475569;
   display: block;
-  font-size: 1.4em;
+  font-size: 1.1em;
   font-weight: bold;
   text-decoration: none;
+  border-bottom: 2px solid #cbd5e1;
+  padding: 4px 14px;
+  transition: all 0.3s;
+}
+#quickMenu a::before {
+  content: "";
+  background: #94a3b8;
+  width: 0.7em;
+  height: 0.8em;
+  display: inline-block;
+  clip-path: polygon(0 0, 0 60%, 50% 100%, 100% 60%, 100% 0);
+  border-radius: 2.5px;
+  margin: 0 7px 0 0;
+  transform: rotate(-90deg);
 }
 #quickMenu a:hover {
-  opacity: 0.8;
+  color: #0f172a;
+  border-color: #afbaca;
+  padding: 4px 20px;
+  margin: 0 0;
+  transition: all 0.3s;
+}
+#quickMenu a:hover::before {
+  background: #64748b;
+  transform: rotate(0deg);
 }
 html {
   scroll-behavior: smooth;

--- a/css/side_menu.css
+++ b/css/side_menu.css
@@ -6,7 +6,7 @@
   height: 100%;
   position: fixed;
   z-index: 11;
-  background: #0007;
+  background: #0008;
   opacity: 1;
   visibility: visible;
   transition: opacity 300ms;
@@ -16,7 +16,7 @@
   height: 100%;
   position: fixed;
   z-index: 11;
-  background: #0007;
+  background: #0008;
   opacity: 0;
   visibility: hidden;
 }

--- a/src/options/components/blocks/CustomTextField.tsx
+++ b/src/options/components/blocks/CustomTextField.tsx
@@ -1,6 +1,7 @@
 import { Save } from "@mui/icons-material";
-import { Button, Stack, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography, InputAdornment, IconButton } from "@mui/material";
 import { useId, useState, useRef, useEffect } from "react";
+import { MdVisibility, MdVisibilityOff } from "react-icons/md";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
@@ -33,9 +34,16 @@ export const CustomTextField = (props: Props) => {
   const [currentValue, setCurrentValue] = useState<string>(value);
   const [unitPosition, setUnitPosition] = useState<number>(0);
   const [isError, setIsError] = useState<boolean>(false);
+  const [showPassword, setShowPassword] = useState<boolean>(false);
   const id = useId();
 
   const inputRef = useRef(null);
+
+  const handleClickShowPassword = () => setShowPassword((show) => !show);
+
+  const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
 
   useEffect(() => {
     const ref = inputRef.current as HTMLInputElement;
@@ -47,8 +55,6 @@ export const CustomTextField = (props: Props) => {
     const width = context.measureText(currentValue || placeholder).width;
     setUnitPosition(width);
   }, [inputRef, currentValue, unit, placeholder]);
-
-  console.log({ value, currentValue });
 
   return (
     <CustomContainerParent
@@ -65,13 +71,31 @@ export const CustomTextField = (props: Props) => {
               size="small"
               value={currentValue}
               onChange={(e) => setCurrentValue(e.target.value)}
-              sx={{ width: 450, zIndex: 1 }}
-              type={type}
+              sx={{
+                width: 450,
+                zIndex: 1,
+                "& *::-ms-reveal": {
+                  display: "none",
+                },
+              }}
+              type={type === "password" ? (showPassword ? "text" : "password") : type}
               id={id}
               placeholder={placeholder}
               inputRef={inputRef}
               error={isError}
-              inputProps={{ pattern }}
+              inputProps={{
+                pattern,
+              }}
+              InputProps={{
+                endAdornment:
+                  type === "password" ? (
+                    <InputAdornment position="end">
+                      <IconButton onClick={handleClickShowPassword} onMouseDown={handleMouseDownPassword}>
+                        {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
+                      </IconButton>
+                    </InputAdornment>
+                  ) : null,
+              }}
             />
             {unit && (
               <Typography

--- a/src/options/components/blocks/CustomTextField.tsx
+++ b/src/options/components/blocks/CustomTextField.tsx
@@ -1,6 +1,6 @@
 import { Save } from "@mui/icons-material";
-import { Button, Stack, TextField } from "@mui/material";
-import { useId, useState } from "react";
+import { Button, Stack, TextField, Typography } from "@mui/material";
+import { useId, useState, useRef, useEffect } from "react";
 import { CustomContainerParent } from "./CustomContainerParent";
 
 type Props = {
@@ -9,14 +9,46 @@ type Props = {
   optionId?: string;
   type?: string;
   value: string;
+  placeholder?: string;
+  unit?: string;
+  pattern?: string;
+  validateMessage?: string;
   onSaveButtonClick: (value: string) => void;
 };
 
 export const CustomTextField = (props: Props) => {
-  const { i18nLabel, i18nCaption, optionId = "", value, type, onSaveButtonClick } = props;
+  const {
+    i18nLabel,
+    i18nCaption,
+    optionId = "",
+    value,
+    type,
+    placeholder = "",
+    unit,
+    pattern,
+    validateMessage = "Invalid input",
+    onSaveButtonClick,
+  } = props;
 
-  const [currentValue, setCurrentValue] = useState(value);
+  const [currentValue, setCurrentValue] = useState<string>(value);
+  const [unitPosition, setUnitPosition] = useState<number>(0);
+  const [isError, setIsError] = useState<boolean>(false);
   const id = useId();
+
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    const ref = inputRef.current as HTMLInputElement;
+    setIsError(!ref.validity.valid);
+    if (!unit) return;
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    context.font = getComputedStyle(ref).font;
+    const width = context.measureText(currentValue || placeholder).width;
+    setUnitPosition(width);
+  }, [inputRef, currentValue, unit, placeholder]);
+
+  console.log({ value, currentValue });
 
   return (
     <CustomContainerParent
@@ -25,24 +57,51 @@ export const CustomTextField = (props: Props) => {
       optionId={optionId}
       htmlFor={id}
     >
-      <Stack direction="row" gap={1}>
-        <TextField
-          variant="outlined"
-          size="small"
-          value={currentValue}
-          onChange={(e) => setCurrentValue(e.target.value)}
-          sx={{ width: 450 }}
-          type={type}
-          id={id}
-        />
-        <Button
-          startIcon={<Save />}
-          variant="contained"
-          onClick={() => onSaveButtonClick(currentValue)}
-          disabled={value === currentValue}
-        >
-          {chrome.i18n.getMessage("dialogSave")}
-        </Button>
+      <Stack direction="column" gap={0.8}>
+        <Stack direction="row" gap={1}>
+          <Stack direction="row" gap={1} position="relative">
+            <TextField
+              variant="outlined"
+              size="small"
+              value={currentValue}
+              onChange={(e) => setCurrentValue(e.target.value)}
+              sx={{ width: 450, zIndex: 1 }}
+              type={type}
+              id={id}
+              placeholder={placeholder}
+              inputRef={inputRef}
+              error={isError}
+              inputProps={{ pattern }}
+            />
+            {unit && (
+              <Typography
+                variant="body2"
+                sx={{
+                  position: "absolute",
+                  opacity: 0.6,
+                  left: unitPosition + 24,
+                  top: 10,
+                  bottom: 0,
+                }}
+              >
+                {unit}
+              </Typography>
+            )}
+          </Stack>
+          <Button
+            startIcon={<Save />}
+            variant="contained"
+            onClick={() => onSaveButtonClick(currentValue)}
+            disabled={value === currentValue || isError}
+          >
+            {chrome.i18n.getMessage("dialogSave")}
+          </Button>
+        </Stack>
+        {isError && (
+          <Typography variant="caption" color="error" sx={{ ml: 1.5 }}>
+            {validateMessage}
+          </Typography>
+        )}
       </Stack>
     </CustomContainerParent>
   );

--- a/src/options/components/pages/AdvancedOptions.tsx
+++ b/src/options/components/pages/AdvancedOptions.tsx
@@ -60,6 +60,8 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="科目別ページの最大幅を設定します。"
           optionId="layout.maxWidthPx.subj"
           value={saves.settings.layout.maxWidthPx.subj.toString()}
+          placeholder="1280"
+          unit="px"
           onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,
@@ -182,6 +184,8 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="レポート提出時に、作成時間を簡易入力するためのスライダーバーの最大値を設定します。"
           optionId="sliderBarMax"
           value={saves.settings.sliderBarMax.toString()}
+          unit="分"
+          placeholder="600"
           onSaveButtonClick={(value) => setSettings("sliderBarMax", parseInt(value, 10))}
         />
         <CustomSelect
@@ -200,6 +204,7 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="レポート提出時にファイル名自動入力ボタンを押した際に入力される文字列を変更します。"
           optionId="defaultInputName"
           value={saves.settings.defaultInputName}
+          placeholder="AA00000_山田太郎"
           onSaveButtonClick={(value) => setSettings("defaultInputName", value)}
         />
         <CustomTextField
@@ -208,6 +213,8 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="課題提出ページの最大幅を設定します。"
           optionId="layout.maxWidthPx.task"
           value={saves.settings.layout.maxWidthPx.task.toString()}
+          placeholder="1280"
+          unit="px"
           onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,
@@ -245,6 +252,8 @@ export const AdvancedOptions = (props: Props) => {
           i18nCaption="LMSページの最大幅を設定します。"
           optionId="layout.maxWidthPx.lms"
           value={saves.settings.layout.maxWidthPx.lms.toString()}
+          placeholder="1280"
+          unit="px"
           onSaveButtonClick={(value) =>
             setSettings("layout", {
               ...saves.settings.layout,

--- a/src/options/components/pages/BasicOptions.tsx
+++ b/src/options/components/pages/BasicOptions.tsx
@@ -36,8 +36,11 @@ export const BasicOptions = (props: Props) => {
           i18nCaption="optionDescriptionStudentID"
           optionId="loginData.username"
           value={saves.settings.loginData.username.split("@")[0]}
+          placeholder="XX00000"
+          pattern="^([a-zA-Z]{2}[0-9]{5})$"
+          validateMessage="学籍番号は2文字のアルファベットと5文字の数字の組み合わせで入力してください。"
           onSaveButtonClick={(value) => {
-            const username = value.includes("@") ? value : value + "@sic";
+            const username = value + "@sic";
             setSettings("loginData", { ...saves.settings.loginData, username });
           }}
         />
@@ -47,6 +50,7 @@ export const BasicOptions = (props: Props) => {
           i18nCaption="optionDescriptionPassword"
           optionId="loginData.password"
           value={saves.settings.loginData.password}
+          placeholder="password"
           onSaveButtonClick={(value) => setSettings("loginData", { ...saves.settings.loginData, password: value })}
         />
         <CustomSwitch

--- a/src/options/components/pages/WidgetOptions.tsx
+++ b/src/options/components/pages/WidgetOptions.tsx
@@ -237,6 +237,8 @@ export const WidgetOptions = (props: Props) => {
           i18nCaption="ウィジェットを表示できる領域のうち、どれくらいの幅(%)を割り当てるか指定します。 100%にすると、画面いっぱいに表示されるためメニューを閉じづらくなることがあります。"
           optionId="widgetWidth"
           value={saves.settings.widgetWidth.toString()}
+          placeholder="100"
+          unit="%"
           onSaveButtonClick={(value) => setSettings("widgetWidth", parseInt(value, 10))}
         />
         <CustomTextField
@@ -245,15 +247,19 @@ export const WidgetOptions = (props: Props) => {
           i18nCaption="ウィジェットの最大幅(px)を指定します。 この値を超える幅にはなりません。"
           optionId="widgetMaxWidth"
           value={saves.settings.widgetMaxWidth.toString()}
+          placeholder="1200"
+          unit="px"
           onSaveButtonClick={(value) => setSettings("widgetMaxWidth", parseInt(value, 10))}
         />
         <CustomTextField
           i18nLabel="ウィジェット拡大率"
           type="number"
-          i18nCaption="ウィジェットの拡大率を指定します。 1.0で通常表示、1.5で1.5倍表示となります。"
+          i18nCaption="ウィジェットの拡大率を指定します。 100%で通常表示、150%で1.5倍表示となります。"
           optionId="widgetZoom"
-          value={saves.settings.widgetZoom.toString()}
-          onSaveButtonClick={(value) => setSettings("widgetZoom", parseFloat(value))}
+          value={(saves.settings.widgetZoom * 100).toString()}
+          placeholder="100"
+          unit="%"
+          onSaveButtonClick={(value) => setSettings("widgetZoom", parseFloat(value) / 100)}
         />
       </OptionGroup>
       <OptionGroup i18nTitle="時間割ウィジェット">
@@ -334,6 +340,7 @@ export const WidgetOptions = (props: Props) => {
           i18nCaption="メニュー横ウィジェットの課題一覧で、提出期限の表示形式が絶対表示の時の表示フォーマットを変更します。 yyyy:年 MM:月 E:曜日 dd:日 HH:時 mm:分"
           optionId="deadlineFormat"
           value={saves.settings.deadlineFormat}
+          placeholder="yyyy/MM/dd HH:mm"
           onSaveButtonClick={(value) => setSettings("deadlineFormat", value)}
         />
         <CustomTextField
@@ -342,6 +349,10 @@ export const WidgetOptions = (props: Props) => {
           i18nCaption="メニュー横ウィジェットの課題一覧で、1ページ内に表示する課題の最大件数を設定します。 課題の数がこれを超えた場合であっても、ページネーションにより全ての課題を確認できます。"
           optionId="taskListRowsPerPage"
           value={saves.settings.taskListRowsPerPage.toString()}
+          placeholder="5"
+          unit="件"
+          pattern="^[0-9]+$"
+          validateMessage="整数で入力してください。"
           onSaveButtonClick={(value) => setSettings("taskListRowsPerPage", parseInt(value, 10))}
         />
         <CustomRemovableList

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -18,6 +18,7 @@ import {
   Snackbar,
   Stack,
   ThemeProvider,
+  CircularProgress,
 } from "@mui/material";
 import { indigo, grey } from "@mui/material/colors";
 import React, { useEffect, useState } from "react";
@@ -37,7 +38,7 @@ import "./index.css";
 
 const OptionsIndex = () => {
   const [currentTab, setCurrentTab] = useState(new URLSearchParams(window.location.search).get("tab") || "basic");
-  const [currentLocalStorage, setCurrentLocalStorage] = useState<Saves>(defaultSaves);
+  const [currentLocalStorage, setCurrentLocalStorage] = useState<Saves>(null);
   const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
 
   const setSettings = async (key: string, value: unknown) => {
@@ -164,22 +165,38 @@ const OptionsIndex = () => {
             padding: "1rem",
           }}
         >
-          {(currentTab === "basic" || currentTab === null) && (
-            <BasicOptions saves={currentLocalStorage} setSettings={setSettings} />
+          {currentLocalStorage === null ? (
+            <Box
+              sx={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              <CircularProgress size={60} />
+            </Box>
+          ) : (
+            <>
+              {(currentTab === "basic" || currentTab === null) && (
+                <BasicOptions saves={currentLocalStorage} setSettings={setSettings} />
+              )}
+              {currentTab === "widget" && <WidgetOptions saves={currentLocalStorage} setSettings={setSettings} />}
+              {currentTab === "layout" && <LayoutOptions saves={currentLocalStorage} setSettings={setSettings} />}
+              {currentTab === "advanced" && (
+                <AdvancedOptions saves={currentLocalStorage} setSettings={setSettings} setScombzData={setScombzData} />
+              )}
+              {currentTab === "customcss" && (
+                <CustomCSS
+                  value={currentLocalStorage.settings.customCSS}
+                  onSaveButtonClick={(value) => setSettings("customCSS", value)}
+                />
+              )}
+              {currentTab === "data" && <DataOperation saves={currentLocalStorage} setSaves={setCurrentLocalStorage} />}
+              {currentTab === "info" && <Information />}
+            </>
           )}
-          {currentTab === "widget" && <WidgetOptions saves={currentLocalStorage} setSettings={setSettings} />}
-          {currentTab === "layout" && <LayoutOptions saves={currentLocalStorage} setSettings={setSettings} />}
-          {currentTab === "advanced" && (
-            <AdvancedOptions saves={currentLocalStorage} setSettings={setSettings} setScombzData={setScombzData} />
-          )}
-          {currentTab === "customcss" && (
-            <CustomCSS
-              value={currentLocalStorage.settings.customCSS}
-              onSaveButtonClick={(value) => setSettings("customCSS", value)}
-            />
-          )}
-          {currentTab === "data" && <DataOperation saves={currentLocalStorage} setSaves={setCurrentLocalStorage} />}
-          {currentTab === "info" && <Information />}
         </Box>
       </Stack>
     </ThemeProvider>


### PR DESCRIPTION
### **User description**
## 概要

- メニューの背景レイヤー明るさ調整
- クイックメニュースタイリング
- 設定画面のplaceholderとmask, validation
- 設定画面のTextFieldの初期値が空欄になる問題を修正

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [ ] NO

## チェック項目

- [ ] ビルドが通る
- [ ] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
  - [ ] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- `CustomTextField`コンポーネントに新しいプロパティ（`placeholder`、`unit`、`pattern`、`validateMessage`）を追加し、バリデーションとエラーメッセージの表示機能を追加しました。
- `AdvancedOptions`、`BasicOptions`、`WidgetOptions`ページの`CustomTextField`にプレースホルダーとユニットを追加しました。
- ローディングインジケーターを追加し、データがロードされるまでのユーザー体験を向上させました。
- クイックメニューとサイドメニューのスタイリングを調整しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomTextField.tsx</strong><dd><code>TextFieldコンポーネントの機能拡張とバリデーション追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/options/components/blocks/CustomTextField.tsx
<li><code>placeholder</code>、<code>unit</code>、<code>pattern</code>、<code>validateMessage</code>プロパティを追加<br> <li> バリデーションとエラーメッセージの表示を追加<br> <li> ユニットの位置を計算して表示<br>


</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-acb7b7ab64d19f192e53e55dc4c9fccaa788bfd1ded79a2e253ecc7562df6524">+81/-22</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AdvancedOptions.tsx</strong><dd><code>AdvancedOptionsページのTextFieldにプレースホルダーとユニットを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/options/components/pages/AdvancedOptions.tsx
- `CustomTextField`に`placeholder`と`unit`を追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-bf35a3b4821abcca0a0fc36383a2c00ab370a1c157529af0a4bae1c935a21b1e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BasicOptions.tsx</strong><dd><code>BasicOptionsページのTextFieldにバリデーションとプレースホルダーを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/options/components/pages/BasicOptions.tsx
- `CustomTextField`に`placeholder`、`pattern`、`validateMessage`を追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-67afcdf8d22173f0d4b28fe1be63654dbe7fd47923932ceaf3b44be58c076f95">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WidgetOptions.tsx</strong><dd><code>WidgetOptionsページのTextFieldにプレースホルダーとユニットを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/options/components/pages/WidgetOptions.tsx
- `CustomTextField`に`placeholder`と`unit`を追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-b1660983e4a400a4fbd1df5c8c51a96731346f6c41b9428b14d5a2713d01ef40">+14/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>ローディングインジケーターの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/options/index.tsx
- ローディングインジケーターを追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-167e8b93c584b7e4360f55b6893fdd19a0c4ddbc616a3c03f511ac7e8244c141">+33/-16</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>quickmenu.css</strong><dd><code>クイックメニューのスタイル調整</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

css/quickmenu.css
- クイックメニューのスタイリングを調整



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-ebfe275841c9ad0f04f34666806b44609b3e5e8eb8e86a8b609f0625df443da3">+28/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>side_menu.css</strong><dd><code>サイドメニューの背景色調整</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

css/side_menu.css
- サイドメニューの背景色を調整



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/74/files#diff-09dc666014cd8ba26ac35d026ba5206850581935d1cae7e7ac32a79f96dc7930">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

