### PR TITLE
fix: sidemenuでページ内リンクやダイアログ表示をクリックしたときの表示を修正

### DIFF
--- a/css/side_menu.css
+++ b/css/side_menu.css
@@ -119,6 +119,9 @@ img.scombz-icon {
 .sidemenu-link.sidemenu-lms-link.sidemenu-link-txt:hover {
   background: #f0f0f0;
 }
+a.sidemenu-link.sidemenu-lms-link.sidemenu-link-txt:active {
+  background-color: #e0e0e0;
+}
 #sidemenu {
   box-shadow: none;
   overflow-y: auto;

--- a/src/contents/sideMenu.ts
+++ b/src/contents/sideMenu.ts
@@ -16,16 +16,34 @@ const styleSidemenu = async () => {
     return;
   }
 
+  const anchors = document.querySelectorAll(
+    "a.sidemenu-link.sidemenu-lms-link.sidemenu-link-txt.sidemenu-icon",
+  ) as NodeListOf<HTMLAnchorElement>;
+
   const link = document.createElement("link");
   link.href = chrome.runtime.getURL("css/side_menu.css"); // 新しいCSSファイルのパス
   link.type = "text/css";
   link.rel = "stylesheet";
   document.head.appendChild(link);
 
+  // ページ内リンクをクリックしたときにメニューを閉じる
+  document.querySelectorAll(".sidemenu-list a.sidemenu-list-colomn").forEach((element) => {
+    element.addEventListener("click", () => {
+      document.getElementById("sidemenuClose").click();
+    });
+  });
+  if (location.href.startsWith("https://scombz.shibaura-it.ac.jp/portal/home")) {
+    anchors.forEach((anchor) => {
+      const onclick = anchor.getAttribute("onclick");
+      if (onclick && onclick.startsWith("portalHomeAnchor")) {
+        anchor.addEventListener("click", () => {
+          document.getElementById("sidemenuClose").click();
+        });
+      }
+    });
+  }
+
   // 英語だといくつか改行されてしまう
-  const anchors = document.querySelectorAll(
-    "a.sidemenu-link.sidemenu-lms-link.sidemenu-link-txt.task-color.sidemenu-icon",
-  ) as NodeListOf<HTMLAnchorElement>;
   for (const anchor of anchors) {
     if (anchor.textContent?.length > 19) {
       anchor.style.paddingTop = "2px";


### PR DESCRIPTION
### **User description**
## 概要

- やること、やったことを書く

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [ ] NO

## チェック項目

- [ ] ビルドが通る
- [ ] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
  - [ ] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント


___

### **PR Type**
Enhancement


___

### **Description**
- ページ内リンクをクリックしたときにサイドメニューを閉じる処理を追加しました。
- 特定のリンクに対してクリックイベントを追加し、サイドメニューを閉じるようにしました。
- リンクのアクティブ状態のスタイルを追加しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sideMenu.ts</strong><dd><code>サイドメニューのリンククリック時の動作を改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/contents/sideMenu.ts
<li>ページ内リンクをクリックしたときにサイドメニューを閉じる処理を追加<br> <li> 特定のリンクに対してクリックイベントを追加<br> <li> アンカー要素の取得ロジックを修正<br>


</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/75/files#diff-9880dfe292dc8c41ec96542c290a1beefd47cc6c473c0232eddaacb7558b25fd">+21/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>side_menu.css</strong><dd><code>リンクのアクティブ状態のスタイルを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

css/side_menu.css
- リンクのアクティブ状態のスタイルを追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/75/files#diff-09dc666014cd8ba26ac35d026ba5206850581935d1cae7e7ac32a79f96dc7930">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

