### PR TITLE
ポップアップ機能の移植完了

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -271,6 +271,10 @@
     "message": "Layout",
     "description": "レイアウト設定"
   },
+  "popupOptions": {
+    "message": "Popup",
+    "description": "ポップアップ設定"
+  },
   "advancedOptions": {
     "message": "Advanced",
     "description": "詳細設定"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1,8 +1,4 @@
 {
-  "extensionName": {
-    "message": "ScombZ Utilities",
-    "description": "Name of the extension."
-  },
   "extensionDescription": {
     "message": "An extension for ScombZ  easier to use.",
     "description": "Description of the extension."
@@ -124,8 +120,13 @@
     "description": "メモを追加"
   },
   "notepadDeleteConfirm": {
-    "message": "Are you sure you want to delete this note?\n\n_NOTE_",
-    "description": "メモを削除"
+    "message": "Are you sure you want to delete this note?\n$target$",
+    "description": "メモを削除",
+    "placeholders": {
+      "target": {
+        "content": "$1"
+      }
+    }
   },
   "calendar": {
     "message": "Calendar",
@@ -515,5 +516,9 @@
   "popupTimetableIntensiveCourse": {
     "message": "Intensive\ncourses",
     "description": "集中講義"
+  },
+  "basicOptions_ClickLoginButtonAutomatically": {
+    "message": "Automatically click the login button",
+    "description": "ログインボタンを自動クリック"
   }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -462,5 +462,54 @@
   "notSelected": {
     "message": "Please select",
     "description": "未選択"
+  },
+  "andNMore": {
+    "message": "... and $num$ more",
+    "description": "... 他n件",
+    "placeholders": {
+      "num": {
+        "content": "$1"
+      }
+    }
+  },
+  "showAll": {
+    "message": "Show all",
+    "description": "すべて表示"
+  },
+  "popupTabSunday": {
+    "message": "Sun",
+    "description": "日"
+  },
+  "popupTabMonday": {
+    "message": "Mon",
+    "description": "月"
+  },
+  "popupTabTuesday": {
+    "message": "Tue",
+    "description": "火"
+  },
+  "popupTabWednesday": {
+    "message": "Wed",
+    "description": "水"
+  },
+  "popupTabThursday": {
+    "message": "Thu",
+    "description": "木"
+  },
+  "popupTabFriday": {
+    "message": "Fri",
+    "description": "金"
+  },
+  "popupTabSaturday": {
+    "message": "Sat",
+    "description": "土"
+  },
+  "popupTabTasks": {
+    "message": "Tasks",
+    "description": "課題"
+  },
+  "popupTimetableIntensiveCourse": {
+    "message": "Intensive\ncourses",
+    "description": "集中講義"
   }
 }

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -464,6 +464,55 @@
     "message": "未選択",
     "description": "未選択"
   },
+  "andNMore": {
+    "message": "... 他$num$件",
+    "description": "... 他n件",
+    "placeholders": {
+      "num": {
+        "content": "$1"
+      }
+    }
+  },
+  "showAll": {
+    "message": "すべて表示",
+    "description": "すべて表示"
+  },
+  "popupTabSunday": {
+    "message": "日",
+    "description": "日"
+  },
+  "popupTabMonday": {
+    "message": "月",
+    "description": "月"
+  },
+  "popupTabTuesday": {
+    "message": "火",
+    "description": "火"
+  },
+  "popupTabWednesday": {
+    "message": "水",
+    "description": "水"
+  },
+  "popupTabThursday": {
+    "message": "木",
+    "description": "木"
+  },
+  "popupTabFriday": {
+    "message": "金",
+    "description": "金"
+  },
+  "popupTabSaturday": {
+    "message": "土",
+    "description": "土"
+  },
+  "popupTabTasks": {
+    "message": "課題",
+    "description": "課題"
+  },
+  "popupTimetableIntensiveCourse": {
+    "message": "その他",
+    "description": "集中講義"
+  },
   "basicOptions_ClickLoginButtonAutomatically": {
     "message": "ログインボタンを自動クリック",
     "description": "ログインボタンを自動クリック"

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -272,6 +272,10 @@
     "message": "レイアウト設定",
     "description": "レイアウト設定"
   },
+  "popupOptions": {
+    "message": "ポップアップ設定",
+    "description": "ポップアップ設定"
+  },
   "advancedOptions": {
     "message": "詳細設定",
     "description": "詳細設定"

--- a/src/backgrounds/badge.ts
+++ b/src/backgrounds/badge.ts
@@ -37,7 +37,8 @@ export const updateBadgeText = () => {
 
     const filteredTaskList = mergedTaskList
       .filter((task) => Date.parse(task.deadline) >= now)
-      .filter((task) => !currentData.settings.hiddenTaskIdList.includes(task.id));
+      .filter((task) => !currentData.settings.hiddenTaskIdList.includes(task.id))
+      .filter((task) => !currentData.settings.popupHideFutureTasks || (Date.parse(task.deadline) - now) / 86400000 < currentData.settings.popupHideFutureTasksRange);
 
     filteredTaskList.sort((a, b) => Date.parse(a.deadline) - Date.parse(b.deadline));
 

--- a/src/backgrounds/migration.ts
+++ b/src/backgrounds/migration.ts
@@ -76,7 +76,7 @@ const oldSavesTemp = {
   popupOverflowMode: "hidden",
   popupTasksLinks: true,
   popupTasksTab: true,
-  popupUncountFutureTaskDays: "365",
+  popupUncountFutureTaskDays: "365", //
   quarterCount: 0,
   remomveDirectLink: true,
   reportHide: false,
@@ -154,6 +154,10 @@ export const migrateLogic = (oldSaves: any): Saves => {
   };
   newSaves.settings.popupBadge =
     oldSaves?.popupBadge ?? newSaves?.settings?.popupBadge ?? defaultSaves.settings.popupBadge;
+  newSaves.settings.popupTasksTab = oldSaves?.popupTasksTab ?? newSaves?.settings?.popupTasksTab ?? defaultSaves.settings.popupTasksTab;
+  newSaves.settings.popupOverflowMode = oldSaves?.popupOverflowMode && oldSaves.popupOverflowMode === "scroll" ? "auto" : newSaves?.settings.popupOverflowMode ?? defaultSaves.settings.popupOverflowMode;
+  newSaves.settings.popupHideFutureTasksRange = oldSaves?.popupUncountFutureTaskDays ?? newSaves?.settings?.popupHideFutureTasksRange ?? defaultSaves.settings.popupHideFutureTasksRange;
+  newSaves.settings.popupHideFutureTasks = oldSaves?.popupUncountFutureTaskDays && oldSaves.popupUncountFutureTaskDays < 365 ? true : newSaves?.settings.popupHideFutureTasks ?? defaultSaves.settings.popupHideFutureTasks;
   newSaves.settings.removeAttendance =
     oldSaves?.attendance ?? newSaves?.settings?.removeAttendance ?? defaultSaves.settings.removeAttendance;
   newSaves.settings.notifySurveySubjects =

--- a/src/backgrounds/migration.ts
+++ b/src/backgrounds/migration.ts
@@ -154,10 +154,20 @@ export const migrateLogic = (oldSaves: any): Saves => {
   };
   newSaves.settings.popupBadge =
     oldSaves?.popupBadge ?? newSaves?.settings?.popupBadge ?? defaultSaves.settings.popupBadge;
-  newSaves.settings.popupTasksTab = oldSaves?.popupTasksTab ?? newSaves?.settings?.popupTasksTab ?? defaultSaves.settings.popupTasksTab;
-  newSaves.settings.popupOverflowMode = oldSaves?.popupOverflowMode && oldSaves.popupOverflowMode === "scroll" ? "auto" : newSaves?.settings.popupOverflowMode ?? defaultSaves.settings.popupOverflowMode;
-  newSaves.settings.popupHideFutureTasksRange = oldSaves?.popupUncountFutureTaskDays ?? newSaves?.settings?.popupHideFutureTasksRange ?? defaultSaves.settings.popupHideFutureTasksRange;
-  newSaves.settings.popupHideFutureTasks = oldSaves?.popupUncountFutureTaskDays && oldSaves.popupUncountFutureTaskDays < 365 ? true : newSaves?.settings.popupHideFutureTasks ?? defaultSaves.settings.popupHideFutureTasks;
+  newSaves.settings.popupTasksTab =
+    oldSaves?.popupTasksTab ?? newSaves?.settings?.popupTasksTab ?? defaultSaves.settings.popupTasksTab;
+  newSaves.settings.popupOverflowMode =
+    oldSaves?.popupOverflowMode && oldSaves.popupOverflowMode === "scroll"
+      ? "auto"
+      : newSaves?.settings?.popupOverflowMode ?? defaultSaves.settings.popupOverflowMode;
+  newSaves.settings.popupHideFutureTasksRange =
+    oldSaves?.popupUncountFutureTaskDays ??
+    newSaves?.settings?.popupHideFutureTasksRange ??
+    defaultSaves.settings.popupHideFutureTasksRange;
+  newSaves.settings.popupHideFutureTasks =
+    oldSaves?.popupUncountFutureTaskDays && oldSaves.popupUncountFutureTaskDays < 365
+      ? true
+      : newSaves?.settings?.popupHideFutureTasks ?? defaultSaves.settings.popupHideFutureTasks;
   newSaves.settings.removeAttendance =
     oldSaves?.attendance ?? newSaves?.settings?.removeAttendance ?? defaultSaves.settings.removeAttendance;
   newSaves.settings.notifySurveySubjects =

--- a/src/contents/components/TaskList.tsx
+++ b/src/contents/components/TaskList.tsx
@@ -29,6 +29,7 @@ import { defaultSaves } from "../util/settings";
 import type { Saves } from "../util/settings";
 import { OriginalTaskModal } from "./originalTaskModal";
 import { MAX_HIDDEN_TASKS } from "~/constants";
+import type { RuntimeMessage } from "~background";
 import { fetchTasks } from "~contents/tasks";
 
 const getTaskColor = (
@@ -352,10 +353,10 @@ export const TaskList = (props: Props) => {
     setTasklist(newTaskList);
     const saveHiddenTaskIdList = async () => {
       const currentData = (await chrome.storage.local.get(defaultSaves)) as Saves;
-      currentData.settings.hiddenTaskIdList = hiddenTaskIdList.filter((id) =>
-        tasklist.map((task) => task.id).includes(id),
-      );
-      chrome.storage.local.set(currentData);
+      currentData.settings.hiddenTaskIdList = hiddenTaskIdList;
+      chrome.storage.local.set(currentData, () => {
+        chrome.runtime.sendMessage({ action: "updateBadgeText" } as RuntimeMessage);
+      });
     };
     saveHiddenTaskIdList();
   }, [hiddenTaskIdList]);

--- a/src/options/components/pages/AdvancedOptions.tsx
+++ b/src/options/components/pages/AdvancedOptions.tsx
@@ -335,13 +335,6 @@ export const AdvancedOptions = (props: Props) => {
           onChange={(e, _) => setSettings("headLinkTo", e.target.value)}
         />
         <CustomSwitch
-          i18nLabel="未提出課題数のバッジ表示"
-          i18nCaption="未提出の課題の個数をバッジに表示します。"
-          optionId="popupBadge"
-          value={saves.settings.popupBadge}
-          onChange={(_e, checked) => setSettings("popupBadge", checked)}
-        />
-        <CustomSwitch
           i18nLabel="S*gsot学番自動入力"
           i18nCaption="S*gsotのログイン時、ユーザー名入力欄に学籍番号を自動入力します。"
           optionId="autoFillSgsot"

--- a/src/options/components/pages/PopupOptions.tsx
+++ b/src/options/components/pages/PopupOptions.tsx
@@ -1,0 +1,70 @@
+import { Box, Typography } from "@mui/material";
+import { CustomSelect } from "~/options/components/blocks/CustomSelect";
+import { CustomSwitch } from "~/options/components/blocks/CustomSwitch";
+import { CustomTextField } from "~/options/components/blocks/CustomTextField";
+import type { Saves, Settings } from "~settings";
+
+type Props = {
+  saves: Saves;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setSettings: (key: keyof Settings, value: any) => void;
+};
+
+export const PopupOptions = (props: Props) => {
+  const { saves, setSettings } = props;
+  return (
+    <Box>
+      <Typography variant="h5">ポップアップ</Typography>
+      <Box display="flex" flexDirection="column" gap={1} p={1}>
+        <CustomSwitch
+          i18nLabel="未提出課題数のバッジ表示"
+          i18nCaption="未提出の課題の個数をバッジに表示します。"
+          optionId="popupBadge"
+          value={saves.settings.popupBadge}
+          onChange={(_e, checked) => setSettings("popupBadge", checked)}
+        />
+        <CustomSwitch
+          i18nLabel="課題タブを表示する"
+          i18nCaption={`ポップアップ内の時間割に課題タブを表示します。
+            課題タブからは未提出の課題を確認することができます。
+            課題タブ内の項目をクリックするとその課題の提出ページを開くことができます。`}
+          optionId="popupTasksTab"
+          value={saves.settings.popupTasksTab}
+          onChange={(_e, checked) => setSettings("popupTasksTab", checked)}
+        />
+        <CustomSelect
+          i18nLabel="課題が多い場合の表示方法"
+          i18nCaption={`課題タブにおいて、課題の数が多いときにあふれた項目を非表示にするかスクロールして表示するか選択できます。`}
+          options={[
+            { value: "hidden", label: "非表示にする" },
+            { value: "scroll", label: "スクロールして表示する" },
+          ]}
+          optionId="popupOverflowMode"
+          value={saves.settings.popupOverflowMode}
+          onChange={(e, _) => setSettings("popupOverflowMode", e.target.value)}
+        />
+        <CustomTextField
+          i18nLabel="期限が一定日数以内の課題をカウント対象とする"
+          type="number"
+          i18nCaption={``}
+          optionId="popupTasksRange"
+          value={saves.settings.popupTasksRange.toString()}
+          onSaveButtonClick={(value) => setSettings("popupTasksRange", parseInt(value, 10))}
+        />
+        <CustomSelect
+          i18nLabel="一定日数より先の課題の表示方法"
+          i18nCaption={`課題タブにおいて、「期限が一定日数以内の課題をカウント対象とする」設定でカウントの対象外となった課題の表示方法を選択できます。`}
+          options={[
+            { value: "normal", label: "通常と同様に表示" },
+            { value: "gray", label: "薄い灰色で表示" },
+            { value: "collapse", label: "折りたたんで表示" },
+            { value: "hidden", label: "非表示" },
+          ]}
+          optionId="popupLaterTasks"
+          value={saves.settings.popupLaterTasks}
+          onChange={(e, _) => setSettings("popupLaterTasks", e.target.value)}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/src/options/components/pages/PopupOptions.tsx
+++ b/src/options/components/pages/PopupOptions.tsx
@@ -15,7 +15,13 @@ export const PopupOptions = (props: Props) => {
   return (
     <Box>
       <Typography variant="h5">ポップアップ</Typography>
+      <Box p={1}>
+        <Typography variant="body2" sx={{ color: "#666" }}>
+          アドレスバー横にあるScombZ Utilitiesをクリックすると表示されるポップアップメニューについての設定を行います。
+        </Typography>
+      </Box>
       <Box display="flex" flexDirection="column" gap={1} p={1}>
+        <Typography variant="h6">基本設定</Typography>
         <CustomSwitch
           i18nLabel="未提出課題数のバッジ表示"
           i18nCaption="未提出の課題の個数をバッジに表示します。"
@@ -43,25 +49,23 @@ export const PopupOptions = (props: Props) => {
           value={saves.settings.popupOverflowMode}
           onChange={(e, _) => setSettings("popupOverflowMode", e.target.value)}
         />
+      </Box>
+      <Box display="flex" flexDirection="column" gap={1} p={1}>
+        <Typography variant="h6">フィルタ機能</Typography>
+        <CustomSwitch
+          i18nLabel="一定日数より先の課題をポップアップから非表示"
+          i18nCaption={`下の「非表示にする日数」で設定した日数よりも提出期限が先の課題について、ポップアップ内の課題一覧に表示されなくなります。また、バッジに表示される未提出の課題の個数のカウントからも除外されます。この設定で非表示になったとしても課題の存在が無くなった訳ではないので注意してください。`}
+          optionId="popupHideFutureTasks"
+          value={saves.settings.popupHideFutureTasks}
+          onChange={(_e, checked) => setSettings("popupHideFutureTasks", checked)}
+        />
         <CustomTextField
-          i18nLabel="期限が一定日数以内の課題をカウント対象とする"
+          i18nLabel="非表示にする日数"
           type="number"
           i18nCaption={``}
-          optionId="popupTasksRange"
-          value={saves.settings.popupTasksRange.toString()}
-          onSaveButtonClick={(value) => setSettings("popupTasksRange", parseInt(value, 10))}
-        />
-        <CustomSelect
-          i18nLabel="一定日数より先の課題の表示方法"
-          i18nCaption={`課題タブにおいて、「期限が一定日数以内の課題をカウント対象とする」設定でカウントの対象外となった課題の表示方法を選択できます。`}
-          options={[
-            { value: "normal", label: "通常と同様に表示" },
-            { value: "gray", label: "薄い灰色で表示" },
-            { value: "hidden", label: "非表示" },
-          ]}
-          optionId="popupLaterTasks"
-          value={saves.settings.popupLaterTasks}
-          onChange={(e, _) => setSettings("popupLaterTasks", e.target.value)}
+          optionId="popupHideFutureTasksRange"
+          value={saves.settings.popupHideFutureTasksRange.toString()}
+          onSaveButtonClick={(value) => setSettings("popupHideFutureTasksRange", parseInt(value, 10))}
         />
       </Box>
     </Box>

--- a/src/options/components/pages/PopupOptions.tsx
+++ b/src/options/components/pages/PopupOptions.tsx
@@ -37,7 +37,7 @@ export const PopupOptions = (props: Props) => {
           i18nCaption={`課題タブにおいて、課題の数が多いときにあふれた項目を非表示にするかスクロールして表示するか選択できます。`}
           options={[
             { value: "hidden", label: "非表示にする" },
-            { value: "scroll", label: "スクロールして表示する" },
+            { value: "auto", label: "スクロールして表示する" },
           ]}
           optionId="popupOverflowMode"
           value={saves.settings.popupOverflowMode}
@@ -57,7 +57,6 @@ export const PopupOptions = (props: Props) => {
           options={[
             { value: "normal", label: "通常と同様に表示" },
             { value: "gray", label: "薄い灰色で表示" },
-            { value: "collapse", label: "折りたたんで表示" },
             { value: "hidden", label: "非表示" },
           ]}
           optionId="popupLaterTasks"

--- a/src/options/components/pages/PopupOptions.tsx
+++ b/src/options/components/pages/PopupOptions.tsx
@@ -40,9 +40,9 @@ export const PopupOptions = (props: Props) => {
         />
         <CustomSelect
           i18nLabel="課題が多い場合の表示方法"
-          i18nCaption={`課題タブにおいて、課題の数が多いときにあふれた項目を非表示にするかスクロールして表示するか選択できます。`}
+          i18nCaption={`課題タブにおいて、課題の数が多いときにあふれた項目を省略するかスクロールして表示するか選択できます。「省略する」を選択した場合は「… 他◯件」をクリックすることでスクロール表示に切り替えることができます。`}
           options={[
-            { value: "hidden", label: "非表示にする" },
+            { value: "hidden", label: "省略する" },
             { value: "auto", label: "スクロールして表示する" },
           ]}
           optionId="popupOverflowMode"

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import { indigo, grey } from "@mui/material/colors";
 import React, { useEffect, useState } from "react";
+import { TbLayersSubtract } from "react-icons/tb";
 
 import { AdvancedOptions } from "~/options/components/pages/AdvancedOptions";
 import { BasicOptions } from "~/options/components/pages/BasicOptions";
@@ -77,6 +78,7 @@ const OptionsIndex = () => {
     { value: "basic", label: chrome.i18n.getMessage("basicOptions"), icon: <SettingsSuggestOutlined /> },
     { value: "widget", label: chrome.i18n.getMessage("widgetOptions"), icon: <WidgetsOutlined /> },
     { value: "layout", label: chrome.i18n.getMessage("layoutOptions"), icon: <ViewQuiltOutlined /> },
+    { value: "popup", label: chrome.i18n.getMessage("popupOptions"), icon: <TbLayersSubtract size={24} /> },
     { value: "advanced", label: chrome.i18n.getMessage("advancedOptions"), icon: <SettingsOutlined /> },
     { value: "customcss", label: chrome.i18n.getMessage("customCSS"), icon: <PaletteOutlined /> },
     { value: "data", label: chrome.i18n.getMessage("manageOptions"), icon: <ManageHistoryOutlined /> },
@@ -143,7 +145,12 @@ const OptionsIndex = () => {
               >
                 <ListItemButton>
                   {menu.icon && (
-                    <ListItemIcon sx={{ color: currentTab === menu.value ? "white" : "black", transition: "all 0.3s" }}>
+                    <ListItemIcon
+                      sx={{
+                        color: currentTab === menu.value ? "white" : "black",
+                        transition: "all 0.3s",
+                      }}
+                    >
                       {menu.icon}
                     </ListItemIcon>
                   )}
@@ -185,6 +192,7 @@ const OptionsIndex = () => {
               )}
               {currentTab === "widget" && <WidgetOptions saves={currentLocalStorage} setSettings={setSettings} />}
               {currentTab === "layout" && <LayoutOptions saves={currentLocalStorage} setSettings={setSettings} />}
+              {currentTab === "popup" && <PopupOptions saves={currentLocalStorage} setSettings={setSettings} />}
               {currentTab === "advanced" && (
                 <AdvancedOptions saves={currentLocalStorage} setSettings={setSettings} setScombzData={setScombzData} />
               )}

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -31,6 +31,7 @@ import { Information } from "~/options/components/pages/Information";
 import { LayoutOptions } from "~/options/components/pages/LayoutOptions";
 import { WidgetOptions } from "~/options/components/pages/WidgetOptions";
 import theme from "~/theme";
+import { PopupOptions } from "~options/components/pages/PopupOptions";
 import { defaultSaves } from "~settings";
 import type { Saves } from "~settings";
 

--- a/src/popup/components/ListCourse.tsx
+++ b/src/popup/components/ListCourse.tsx
@@ -6,27 +6,26 @@ import type { TimeTableData } from "~contents/types/timetable";
 type ListCourseProps = {
   courses: TimeTableData[];
   intensiveCourses: TimeTableData[];
+  lastPeriod: number;
 };
 
 export const ListCourse = (props: ListCourseProps) => {
-  const { courses, intensiveCourses } = props;
-
-  const maxHours = 7;
+  const { courses, intensiveCourses, lastPeriod } = props;
 
   const timeTableData = useMemo(() => {
-    return Array.from({ length: maxHours }, (_, i) => courses.filter((course) => course.time === i + 1));
-  }, [courses, maxHours]);
+    return Array.from({ length: lastPeriod }, (_, i) => courses.filter((course) => course.time === i + 1));
+  }, [courses, lastPeriod]);
 
   const height = useMemo(() => {
     let h = 0;
-    [...timeTableData.slice(0, maxHours)].forEach((d) => {
+    [...timeTableData.slice(0, lastPeriod)].forEach((d) => {
       h += d.length > 1 ? d.length * 30 : 48;
     });
     if (intensiveCourses.length > 0) {
       h += intensiveCourses.length > 1 ? intensiveCourses.length * 30 : 48 + 2;
     }
     return h;
-  }, [courses, intensiveCourses, maxHours]);
+  }, [courses, intensiveCourses, lastPeriod]);
 
   return (
     <>
@@ -36,7 +35,7 @@ export const ListCourse = (props: ListCourseProps) => {
             courses={d}
             time={index + 1}
             key={index}
-            noDivider={index === maxHours - 1 + (intensiveCourses.length > 0 ? 1 : 0)}
+            noDivider={index === lastPeriod - 1 + (intensiveCourses.length > 0 ? 1 : 0)}
             isScrollBarShown={height > 380}
           />
         ))}

--- a/src/popup/components/ListCourse.tsx
+++ b/src/popup/components/ListCourse.tsx
@@ -18,8 +18,6 @@ export const ListCourse = (props: ListCourseProps) => {
   }, [courses, maxHours]);
 
   const height = useMemo(() => {
-    console.log([...timeTableData.slice(0, maxHours), intensiveCourses.length > 0 ? intensiveCourses : null]);
-
     let h = 0;
     [...timeTableData.slice(0, maxHours)].forEach((d) => {
       h += d.length > 1 ? d.length * 30 : 48;
@@ -29,8 +27,6 @@ export const ListCourse = (props: ListCourseProps) => {
     }
     return h;
   }, [courses, intensiveCourses, maxHours]);
-
-  console.log(height);
 
   return (
     <>

--- a/src/popup/components/ListCourse.tsx
+++ b/src/popup/components/ListCourse.tsx
@@ -5,21 +5,51 @@ import type { TimeTableData } from "~contents/types/timetable";
 
 type ListCourseProps = {
   courses: TimeTableData[];
+  intensiveCourses: TimeTableData[];
 };
 
 export const ListCourse = (props: ListCourseProps) => {
-  const { courses } = props;
+  const { courses, intensiveCourses } = props;
+
+  const maxHours = 7;
 
   const timeTableData = useMemo(() => {
-    return Array.from({ length: 7 }, (_, i) => courses.filter((course) => course.time === i + 1));
-  }, [courses]);
+    return Array.from({ length: maxHours }, (_, i) => courses.filter((course) => course.time === i + 1));
+  }, [courses, maxHours]);
+
+  const height = useMemo(() => {
+    let h = 0;
+    [...timeTableData.slice(0, maxHours), intensiveCourses].forEach((d) => {
+      h += d.length > 1 ? d.length * 30 : 48;
+    });
+    if (intensiveCourses.length > 0) h += 2;
+    return h;
+  }, [courses, intensiveCourses, maxHours]);
+
+  console.log(height);
 
   return (
     <>
-      <List dense sx={{ py: 0 }}>
+      <List dense sx={{ py: 0, maxHeight: 380, overflowY: "auto", borderBottom: 1, borderColor: "divider" }}>
         {timeTableData.map((d, index) => (
-          <ListItemCourse courses={d} time={index + 1} key={index} />
+          <ListItemCourse
+            courses={d}
+            time={index + 1}
+            key={index}
+            noDivider={index === maxHours - 1 + (intensiveCourses.length > 0 ? 1 : 0)}
+            isScrollBarShown={height > 380}
+          />
         ))}
+        {intensiveCourses.length > 0 && (
+          <ListItemCourse
+            intensive
+            courses={intensiveCourses}
+            time={-1}
+            key={99}
+            noDivider={true}
+            isScrollBarShown={height > 380}
+          />
+        )}
       </List>
     </>
   );

--- a/src/popup/components/ListCourse.tsx
+++ b/src/popup/components/ListCourse.tsx
@@ -18,11 +18,15 @@ export const ListCourse = (props: ListCourseProps) => {
   }, [courses, maxHours]);
 
   const height = useMemo(() => {
+    console.log([...timeTableData.slice(0, maxHours), intensiveCourses.length > 0 ? intensiveCourses : null]);
+
     let h = 0;
-    [...timeTableData.slice(0, maxHours), intensiveCourses].forEach((d) => {
+    [...timeTableData.slice(0, maxHours)].forEach((d) => {
       h += d.length > 1 ? d.length * 30 : 48;
     });
-    if (intensiveCourses.length > 0) h += 2;
+    if (intensiveCourses.length > 0) {
+      h += intensiveCourses.length > 1 ? intensiveCourses.length * 30 : 48 + 2;
+    }
     return h;
   }, [courses, intensiveCourses, maxHours]);
 

--- a/src/popup/components/ListItemCourse.tsx
+++ b/src/popup/components/ListItemCourse.tsx
@@ -20,7 +20,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
           tabIndex={-1}
           disabled={courses.length == 0}
         >
-          <Stack sx={{ width: 66, pl: 1.25 }}>
+          <Stack sx={{ width: 70, pl: 1.25 }}>
             <ListItemText
               primary={time + "限"}
               secondary={terms[time - 1]}
@@ -37,7 +37,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                 disableGutters
                 sx={{
                   pl: 1,
-                  width: 262,
+                  width: 268,
                   minHeight: 30,
                   position: "relative",
                   ":where(:hover > *):not(:hover):not(:active), :where(:focus-within > *):not(:focus)": {
@@ -64,7 +64,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                 }}
                 key={index}
               >
-                <Typography noWrap={true} sx={{ fontSize: "small", textAlign: "left" }}>
+                <Typography noWrap={true} sx={{ fontSize: "small", textAlign: "left" }} pr={0.5}>
                   {course.name}
                   {course.classroom ? (
                     <Typography component="span" sx={{ ml: 1, fontSize: "small", color: "GrayText" }}>

--- a/src/popup/components/ListItemCourse.tsx
+++ b/src/popup/components/ListItemCourse.tsx
@@ -14,7 +14,12 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
   return (
     <>
       <ListItem disablePadding sx={{ alignItems: "stretch" }}>
-        <ListItemButton disableGutters sx={{ alignItems: "stretch", p: 0, minHeight: 48 }} tabIndex={-1}>
+        <ListItemButton
+          disableGutters
+          sx={{ alignItems: "stretch", p: 0, minHeight: 48 }}
+          tabIndex={-1}
+          disabled={courses.length == 0}
+        >
           <Stack sx={{ width: 66, pl: 1.25 }}>
             <ListItemText
               primary={time + "限"}
@@ -32,7 +37,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                 disableGutters
                 sx={{
                   pl: 1,
-                  width: 286,
+                  width: 262,
                   minHeight: 30,
                   position: "relative",
                   ":where(:hover > *):not(:hover):not(:active), :where(:focus-within > *):not(:focus)": {
@@ -42,9 +47,9 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                   ":after": {
                     content: '""',
                     position: "absolute",
-                    width: 76,
+                    width: 60,
                     height: "100%",
-                    left: -76,
+                    left: -60,
                   },
                   ":hover, :focus": {
                     backgroundColor: "unset",

--- a/src/popup/components/ListItemCourse.tsx
+++ b/src/popup/components/ListItemCourse.tsx
@@ -30,8 +30,12 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
         >
           <Stack sx={{ width: 70, pl: 1.25 }}>
             <ListItemText
-              primary={intensive ? "その他" : time + "限"}
-              secondary={intensive ? "曜日時限不定" : terms[time - 1]}
+              primary={
+                intensive
+                  ? chrome.i18n.getMessage("popupTimetableIntensiveCourse")
+                  : time + chrome.i18n.getMessage("timetablePeriodSubscription")
+              }
+              secondary={intensive ? "" : terms[time - 1]}
               primaryTypographyProps={{ fontSize: "small" }}
               secondaryTypographyProps={{ fontSize: "x-small" }}
               sx={{ flex: "0 0 auto", my: "auto" }}

--- a/src/popup/components/ListItemCourse.tsx
+++ b/src/popup/components/ListItemCourse.tsx
@@ -55,9 +55,9 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                   ":after": {
                     content: '""',
                     position: "absolute",
-                    width: isScrollBarShown ? 76 : 60,
+                    width: 76,
                     height: "100%",
-                    left: isScrollBarShown ? -76 : -60,
+                    left: -76,
                   },
                   ":hover, :focus": {
                     backgroundColor: "unset",
@@ -72,8 +72,19 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                 }}
                 key={index}
               >
-                <Typography noWrap={true} sx={{ fontSize: "small", textAlign: "left" }} pr={0.5}>
-                  {course.name}
+                <Typography noWrap={true} sx={{ textAlign: "left" }} pr={0.5}>
+                  <Typography
+                    component="span"
+                    noWrap={true}
+                    sx={{
+                      fontSize: "small",
+                      display: "inline-block",
+                      overflow: "clip",
+                      maxWidth: isScrollBarShown ? "13em" : "14em",
+                    }}
+                  >
+                    {course.name}
+                  </Typography>
                   {course.classroom ? (
                     <Typography component="span" sx={{ ml: 1, fontSize: "small", color: "GrayText" }}>
                       <span> - </span>

--- a/src/popup/components/ListItemCourse.tsx
+++ b/src/popup/components/ListItemCourse.tsx
@@ -1,18 +1,26 @@
-import { Divider, ListItem, ListItemButton, ListItemText, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Divider, ListItem, ListItemButton, ListItemText, Stack, Tooltip, Typography } from "@mui/material";
 import type { TimeTableData } from "~contents/types/timetable";
 
 type ListItemCourseProps = {
   courses: TimeTableData[];
   time: number;
+  noDivider?: boolean;
+  isScrollBarShown?: boolean;
+  intensive?: boolean;
 };
 
 const terms = ["9:00~10:40", "10:50~12:30", "13:20~15:00", "15:10~16:50", "17:00~18:40", "18:50~20:30", "20:40~22:20"];
 
 export const ListItemCourse = (props: ListItemCourseProps) => {
-  const { courses, time } = props;
+  const { courses, time, noDivider, isScrollBarShown, intensive } = props;
 
   return (
     <>
+      {intensive && (
+        <Box mt={0.25}>
+          <Divider />
+        </Box>
+      )}
       <ListItem disablePadding sx={{ alignItems: "stretch" }}>
         <ListItemButton
           disableGutters
@@ -22,8 +30,8 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
         >
           <Stack sx={{ width: 70, pl: 1.25 }}>
             <ListItemText
-              primary={time + "限"}
-              secondary={terms[time - 1]}
+              primary={intensive ? "その他" : time + "限"}
+              secondary={intensive ? "曜日時限不定" : terms[time - 1]}
               primaryTypographyProps={{ fontSize: "small" }}
               secondaryTypographyProps={{ fontSize: "x-small" }}
               sx={{ flex: "0 0 auto", my: "auto" }}
@@ -37,7 +45,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                 disableGutters
                 sx={{
                   pl: 1,
-                  width: 268,
+                  width: isScrollBarShown ? 252 : 268,
                   minHeight: 30,
                   position: "relative",
                   ":where(:hover > *):not(:hover):not(:active), :where(:focus-within > *):not(:focus)": {
@@ -47,9 +55,9 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
                   ":after": {
                     content: '""',
                     position: "absolute",
-                    width: 60,
+                    width: isScrollBarShown ? 76 : 60,
                     height: "100%",
-                    left: -60,
+                    left: isScrollBarShown ? -76 : -60,
                   },
                   ":hover, :focus": {
                     backgroundColor: "unset",
@@ -82,7 +90,7 @@ export const ListItemCourse = (props: ListItemCourseProps) => {
           </Stack>
         </ListItemButton>
       </ListItem>
-      <Divider />
+      {!noDivider && <Divider />}
     </>
   );
 };

--- a/src/popup/components/ListItemTask.tsx
+++ b/src/popup/components/ListItemTask.tsx
@@ -78,7 +78,7 @@ export const ListItemTask = (props: ListItemTaskProps) => {
                 </>
               }
               secondary={
-                <Stack direction="row" gap={1}>
+                <Stack component="span" direction="row" gap={1}>
                   <span>{getRelativeTime(new Date(task.deadline), new Date())}</span>
                   <span>{format(new Date(task.deadline), "yyyy/MM/dd HH:mm:ss")}</span>
                 </Stack>

--- a/src/popup/components/ListItemTask.tsx
+++ b/src/popup/components/ListItemTask.tsx
@@ -66,7 +66,7 @@ export const ListItemTask = (props: ListItemTaskProps) => {
                       noWrap
                       sx={{
                         ml: 1,
-                        width: isScrollBarShown ? 220 : 230,
+                        width: isScrollBarShown ? 204 : 214,
                         fontSize: "small",
                         color: taskColor.color,
                         fontWeight: taskColor.fontWeight,

--- a/src/popup/components/ListTask.tsx
+++ b/src/popup/components/ListTask.tsx
@@ -12,6 +12,8 @@ const maxItems = 7;
 export const ListTask = (props: ListCourseProps) => {
   const { tasks, overflowTasks = "auto" } = props;
 
+  console.log(overflowTasks);
+
   const slicedTasks = overflowTasks === "hidden" ? tasks.slice(0, maxItems) : tasks;
 
   return (

--- a/src/popup/components/ListTask.tsx
+++ b/src/popup/components/ListTask.tsx
@@ -12,8 +12,6 @@ const maxItems = 7;
 export const ListTask = (props: ListCourseProps) => {
   const { tasks, overflowTasks = "auto" } = props;
 
-  console.log(overflowTasks);
-
   const slicedTasks = overflowTasks === "hidden" ? tasks.slice(0, maxItems) : tasks;
 
   return (

--- a/src/popup/components/MultiPageTimeTable.tsx
+++ b/src/popup/components/MultiPageTimeTable.tsx
@@ -117,6 +117,10 @@ export const MultiPageTimeTable = (props: MultiPageTimeTableProps) => {
     return data;
   }, [courses]);
 
+  const intensiveCourses: TimeTableData[] = useMemo(() => {
+    return courses.filter((course) => course.day === -1);
+  }, [courses]);
+
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
@@ -215,7 +219,7 @@ export const MultiPageTimeTable = (props: MultiPageTimeTableProps) => {
         </Box>
         {days.map((day, index) => (
           <TabPanel value={value} index={index} key={index}>
-            <ListCourse courses={weeklyTimeTableData[day]} key={index} />
+            <ListCourse courses={weeklyTimeTableData[day]} key={index} intensiveCourses={intensiveCourses} />
           </TabPanel>
         ))}
         {showTasks && (

--- a/src/popup/components/MultiPageTimeTable.tsx
+++ b/src/popup/components/MultiPageTimeTable.tsx
@@ -10,7 +10,6 @@ import type { TimeTableData } from "~contents/types/timetable";
 type MultiPageTimeTableProps = {
   courses?: TimeTableData[];
   tasks?: Task[];
-  days: TabDays[];
   showTasks?: boolean;
   overflowTasks?: "auto" | "hidden";
   setOverflowTasksMode: (value: "auto" | "hidden") => void;
@@ -91,7 +90,6 @@ const getTaskTabColor = (
 export const MultiPageTimeTable = (props: MultiPageTimeTableProps) => {
   const {
     courses,
-    days,
     tasks = [],
     showTasks = false,
     overflowTasks = "hidden",
@@ -101,6 +99,21 @@ export const MultiPageTimeTable = (props: MultiPageTimeTableProps) => {
     loadFromSaves,
     lastTaskFetchUnixTime,
   } = props;
+
+  const hasSaturday = useMemo(() => courses.some((day) => day.day === 6), [courses]);
+  const lastPeriod = useMemo(
+    () =>
+      Math.max(
+        courses.reduce((acc, cur) => (cur.time > acc ? cur.time : acc), 0),
+        4,
+      ),
+    [courses],
+  );
+
+  const days = useMemo(() => {
+    const weekdayBase: TabDays[] = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+    return hasSaturday ? weekdayBase : weekdayBase.slice(0, 5);
+  }, [hasSaturday]);
 
   const [value, setValue] = useState<number>(
     days.includes(tabDays[new Date().getDay()]) ? days.findIndex((item) => item === tabDays[new Date().getDay()]) : 0,
@@ -223,7 +236,12 @@ export const MultiPageTimeTable = (props: MultiPageTimeTableProps) => {
         {days.map((day, index) => (
           <TabPanel value={value} index={index} key={index}>
             <Box sx={{ pb: 1 }}>
-              <ListCourse courses={weeklyTimeTableData[day]} key={index} intensiveCourses={intensiveCourses} />
+              <ListCourse
+                courses={weeklyTimeTableData[day]}
+                key={index}
+                intensiveCourses={intensiveCourses}
+                lastPeriod={lastPeriod}
+              />
             </Box>
           </TabPanel>
         ))}

--- a/src/popup/components/TasksBottom.tsx
+++ b/src/popup/components/TasksBottom.tsx
@@ -1,0 +1,62 @@
+import { Box, Button, Tooltip } from "@mui/material";
+import { format } from "date-fns";
+import { useCallback } from "react";
+import { fetchTasks } from "~contents/tasks";
+import type { Task } from "~contents/types/task";
+import theme from "~theme";
+
+type TasksBottomProps = {
+  tasks: Task[];
+  overflowTasks?: "auto" | "hidden";
+  lastTaskFetchUnixTime: number;
+  loadFromSaves: () => void;
+  isFetching: boolean;
+  setIsFetching: (value: boolean) => void;
+  setOverflowTasksMode: (value: "auto" | "hidden") => void;
+};
+
+const maxTasks = 7;
+
+export const TasksBottom = (props: TasksBottomProps) => {
+  const {
+    tasks,
+    overflowTasks,
+    lastTaskFetchUnixTime,
+    loadFromSaves,
+    isFetching,
+    setIsFetching,
+    setOverflowTasksMode,
+  } = props;
+
+  const handleRefresh = useCallback(() => {
+    const fetching = async () => {
+      await fetchTasks(true);
+      loadFromSaves();
+      setIsFetching(false);
+    };
+
+    if (isFetching) return;
+    setIsFetching(true);
+
+    fetching();
+  }, []);
+
+  return (
+    <Box display="flex" justifyContent="space-between" color={theme.palette.grey[600]}>
+      <Box>
+        {overflowTasks === "hidden" && !isFetching && tasks.length > maxTasks && (
+          <Tooltip title={chrome.i18n.getMessage("showAll")}>
+            <Button variant="text" size="small" color="inherit" onClick={() => setOverflowTasksMode("auto")}>
+              {chrome.i18n.getMessage("andNMore", (tasks.length - maxTasks).toString())}
+            </Button>
+          </Tooltip>
+        )}
+      </Box>
+      <Tooltip title={chrome.i18n.getMessage("reloadTaskList")}>
+        <Button variant="text" size="small" color="inherit" disabled={isFetching} onClick={handleRefresh}>
+          {chrome.i18n.getMessage("taskListLastUpdate")}: {format(new Date(lastTaskFetchUnixTime), "yyyy/MM/dd HH:mm")}
+        </Button>
+      </Tooltip>
+    </Box>
+  );
+};

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -21,12 +21,19 @@ const IndexPopup = () => {
     chrome.storage.local.get(defaultSaves, (items: Saves) => {
       setSaves(items);
 
+      const now = new Date().getTime();
+
       // アンケートは通知対象の科目一覧でフィルタリング
       const notifySubjects = items.settings.notifySurveySubjects.map((sbj) => sbj.name);
       const surveyList = items.scombzData.surveyList.filter((d) => notifySubjects.includes(d.course));
 
       const mergedTask = [...items.scombzData.tasklist, ...surveyList, ...items.scombzData.originalTasklist]
         .filter((task) => !items.settings.hiddenTaskIdList.includes(task.id)) // 非表示タスクを除外
+        .filter(
+          (task) =>
+            !items.settings.popupHideFutureTasks ||
+            (Date.parse(task.deadline) - now) / 86400000 < items.settings.popupHideFutureTasksRange,
+        )
         .map((task) => {
           // deadlineをDate型で保持 (formatやsortなどで扱いやすくなるため)
           return { ...task, deadlineDate: new Date(task.deadline) };

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Typography, ThemeProvider } from "@mui/material";
+import SettingsIcon from "@mui/icons-material/Settings";
+import { Box, ThemeProvider, Grid, Stack, Link, IconButton, Divider } from "@mui/material";
 import { useEffect, useState } from "react";
 import { MultiPageTimeTable } from "./components/MultiPageTimeTable";
 import theme from "~/theme";
@@ -34,10 +35,12 @@ const IndexPopup = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Box width={360} textAlign="center" m={2}>
-        <Typography variant="h5">ScombZ Utilities</Typography>
+      <Box width={376} textAlign="center" mt={1}>
+        <Grid>
+          <img src={chrome.runtime.getURL("assets/scombz_utilities.svg")} width={240} alt="ScombZ Utilites" />
+        </Grid>
 
-        <Box my={1}>
+        <Box mt={1} mb={2} mx={2}>
           <Box>
             <MultiPageTimeTable
               courses={saves.scombzData.timetable}
@@ -47,11 +50,54 @@ const IndexPopup = () => {
               overflowTasks="auto"
             />
           </Box>
-
-          <Button variant="contained" onClick={openOptions}>
-            設定を開く
-          </Button>
         </Box>
+
+        <Grid
+          container
+          alignItems="center"
+          sx={{
+            background: theme.palette.grey[300],
+          }}
+          width="100vw"
+          px={1.5}
+          py={0.75}
+          m={-1}
+        >
+          <Grid item xs />
+          <Grid item xs={8}>
+            <Stack
+              direction="row"
+              divider={<Divider orientation="vertical" flexItem />}
+              spacing={2}
+              justifyContent="center"
+            >
+              <Link
+                href="https://scombz.shibaura-it.ac.jp"
+                target="_blank"
+                rel="noopener"
+                color={theme.palette.grey[800]}
+              >
+                ScombZ
+              </Link>
+              <Link
+                href="https://github.com/scombz-utilities/scombz-utilities-react"
+                target="_blank"
+                rel="noopener"
+                color={theme.palette.grey[800]}
+              >
+                GitHub
+              </Link>
+              <Link href="https://scombz-utilities.com" target="_blank" rel="noopener" color={theme.palette.grey[800]}>
+                Support
+              </Link>
+            </Stack>
+          </Grid>
+          <Grid item xs textAlign="right">
+            <IconButton aria-label="options" onClick={openOptions}>
+              <SettingsIcon />
+            </IconButton>
+          </Grid>
+        </Grid>
       </Box>
     </ThemeProvider>
   );

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,6 +1,6 @@
 import SettingsIcon from "@mui/icons-material/Settings";
 import { Box, ThemeProvider, Grid, Stack, Link, IconButton, Divider } from "@mui/material";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { MultiPageTimeTable } from "./components/MultiPageTimeTable";
 import theme from "~/theme";
 import type { Task } from "~contents/types/task";
@@ -13,6 +13,7 @@ const openOptions = () => {
 const IndexPopup = () => {
   const [saves, setSaves] = useState<Saves>(defaultSaves);
   const [tasklist, setTasklist] = useState<Task[]>([]);
+  const [loaded, setLoaded] = useState<boolean>(false);
 
   useEffect(() => {
     chrome.storage.local.get(defaultSaves, (items: Saves) => {
@@ -30,8 +31,13 @@ const IndexPopup = () => {
         });
       mergedTask.sort((a, b) => a.deadlineDate.getTime() - b.deadlineDate.getTime());
       setTasklist(mergedTask);
+
+      setLoaded(true);
     });
   }, []);
+
+  // 時間割内の要素数の変化によって一瞬表示がちらつくのを防止するため
+  if (!loaded) return <></>;
 
   return (
     <ThemeProvider theme={theme}>
@@ -46,7 +52,7 @@ const IndexPopup = () => {
               courses={saves.scombzData.timetable}
               tasks={tasklist}
               days={["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]}
-              showTasks
+              showTasks={saves.settings.popupTasksTab}
               overflowTasks="auto"
             />
           </Box>

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -14,8 +14,10 @@ const IndexPopup = () => {
   const [saves, setSaves] = useState<Saves>(defaultSaves);
   const [tasklist, setTasklist] = useState<Task[]>([]);
   const [loaded, setLoaded] = useState<boolean>(false);
+  const [overflowTasksMode, setOverflowTasksMode] = useState<"auto" | "hidden" | null>(null);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
 
-  useEffect(() => {
+  const loadFromSaves = () => {
     chrome.storage.local.get(defaultSaves, (items: Saves) => {
       setSaves(items);
 
@@ -32,8 +34,14 @@ const IndexPopup = () => {
       mergedTask.sort((a, b) => a.deadlineDate.getTime() - b.deadlineDate.getTime());
       setTasklist(mergedTask);
 
+      if (!overflowTasksMode) setOverflowTasksMode(items.settings.popupOverflowMode);
+
       setLoaded(true);
     });
+  };
+
+  useEffect(() => {
+    loadFromSaves();
   }, []);
 
   // 時間割内の要素数の変化によって一瞬表示がちらつくのを防止するため
@@ -53,7 +61,12 @@ const IndexPopup = () => {
               tasks={tasklist}
               days={["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]}
               showTasks={saves.settings.popupTasksTab}
-              overflowTasks="auto"
+              overflowTasks={overflowTasksMode}
+              setOverflowTasksMode={setOverflowTasksMode}
+              isFetching={isFetching}
+              setIsFetching={setIsFetching}
+              loadFromSaves={loadFromSaves}
+              lastTaskFetchUnixTime={saves.scombzData.lastTaskFetchUnixTime}
             />
           </Box>
         </Box>
@@ -66,7 +79,7 @@ const IndexPopup = () => {
           }}
           width="100vw"
           px={1.5}
-          py={0.75}
+          py={0.5}
           m={-1}
         >
           <Grid item xs />
@@ -99,7 +112,7 @@ const IndexPopup = () => {
             </Stack>
           </Grid>
           <Grid item xs textAlign="right">
-            <IconButton aria-label="options" onClick={openOptions}>
+            <IconButton aria-label="options" onClick={openOptions} size="small">
               <SettingsIcon />
             </IconButton>
           </Grid>

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -67,7 +67,6 @@ const IndexPopup = () => {
             <MultiPageTimeTable
               courses={saves.scombzData.timetable}
               tasks={tasklist}
-              days={["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]}
               showTasks={saves.settings.popupTasksTab}
               overflowTasks={overflowTasksMode}
               setOverflowTasksMode={setOverflowTasksMode}

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -57,12 +57,26 @@ const IndexPopup = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Box width={376} textAlign="center" mt={1}>
+      <Box
+        width={376}
+        maxWidth={376}
+        overflow={process.env.PLASMO_BROWSER === "firefox" && "hidden"}
+        textAlign="center"
+        mt={process.env.PLASMO_BROWSER !== "firefox" && 1}
+      >
         <Grid>
-          <img src={chrome.runtime.getURL("assets/scombz_utilities.svg")} width={240} alt="ScombZ Utilites" />
+          <img
+            src={chrome.runtime.getURL("assets/scombz_utilities.svg")}
+            width={process.env.PLASMO_BROWSER === "firefox" ? 200 : 240}
+            alt="ScombZ Utilites"
+          />
         </Grid>
 
-        <Box mt={1} mb={process.env.PLASMO_BROWSER !== "firefox" ? 2 : 1} mx={2}>
+        <Box
+          mt={process.env.PLASMO_BROWSER === "firefox" ? 0.5 : 1}
+          mb={process.env.PLASMO_BROWSER === "firefox" ? 0.5 : 2}
+          mx={2}
+        >
           <Box>
             <MultiPageTimeTable
               courses={saves.scombzData.timetable}
@@ -84,7 +98,7 @@ const IndexPopup = () => {
           sx={{
             background: theme.palette.grey[300],
           }}
-          width={process.env.PLASMO_BROWSER !== "firefox" ? "100vw" : "100%"}
+          width={process.env.PLASMO_BROWSER === "firefox" ? "100%" : "100vw"}
           px={1.5}
           py={0.5}
           m={process.env.PLASMO_BROWSER !== "firefox" && -1}

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -62,7 +62,7 @@ const IndexPopup = () => {
           <img src={chrome.runtime.getURL("assets/scombz_utilities.svg")} width={240} alt="ScombZ Utilites" />
         </Grid>
 
-        <Box mt={1} mb={2} mx={2}>
+        <Box mt={1} mb={process.env.PLASMO_BROWSER !== "firefox" ? 2 : 1} mx={2}>
           <Box>
             <MultiPageTimeTable
               courses={saves.scombzData.timetable}
@@ -84,10 +84,10 @@ const IndexPopup = () => {
           sx={{
             background: theme.palette.grey[300],
           }}
-          width="100vw"
+          width={process.env.PLASMO_BROWSER !== "firefox" ? "100vw" : "100%"}
           px={1.5}
           py={0.5}
-          m={-1}
+          m={process.env.PLASMO_BROWSER !== "firefox" && -1}
         >
           <Grid item xs />
           <Grid item xs={8}>

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -29,6 +29,7 @@ const IndexPopup = () => {
 
       const mergedTask = [...items.scombzData.tasklist, ...surveyList, ...items.scombzData.originalTasklist]
         .filter((task) => !items.settings.hiddenTaskIdList.includes(task.id)) // 非表示タスクを除外
+        .filter((task) => Date.parse(task.deadline) >= now)
         .filter(
           (task) =>
             !items.settings.popupHideFutureTasks ||

--- a/src/popup/styleBody.ts
+++ b/src/popup/styleBody.ts
@@ -1,0 +1,7 @@
+export const styleBody = () => {
+  const link = document.createElement("link");
+  link.href = chrome.runtime.getURL("css/body_no_margin.css");
+  link.type = "text/css";
+  link.rel = "stylesheet";
+  document.head.appendChild(link);
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -103,7 +103,7 @@ export const defaultSettings: Settings = {
   },
   popupBadge: true,
   popupTasksTab: true,
-  popupOverflowMode: "auto",
+  popupOverflowMode: "hidden",
   popupHideFutureTasks: false,
   popupHideFutureTasksRange: 365,
   removeAttendance: "none",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,10 @@ export type Settings = {
     password: string;
   };
   popupBadge: boolean;
+  popupTasksTab: boolean;
+  popupOverflowMode: "hidden" | "scroll";
+  popupTasksRange: number;
+  popupLaterTasks: "normal" | "gray" | "collapse" | "hidden";
   removeAttendance: "none" | "only" | "all";
   notifySurveySubjects: Subject[];
   autoAdfs: boolean;
@@ -98,6 +102,10 @@ export const defaultSettings: Settings = {
     password: "",
   },
   popupBadge: true,
+  popupTasksTab: true,
+  popupOverflowMode: "scroll",
+  popupTasksRange: 365,
+  popupLaterTasks: "gray",
   removeAttendance: "none",
   notifySurveySubjects: [],
   autoAdfs: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,8 +17,8 @@ export type Settings = {
   popupBadge: boolean;
   popupTasksTab: boolean;
   popupOverflowMode: "hidden" | "auto";
-  popupTasksRange: number;
-  popupLaterTasks: "normal" | "gray" | "hidden";
+  popupHideFutureTasks: boolean;
+  popupHideFutureTasksRange: number;
   removeAttendance: "none" | "only" | "all";
   notifySurveySubjects: Subject[];
   autoAdfs: boolean;
@@ -104,8 +104,8 @@ export const defaultSettings: Settings = {
   popupBadge: true,
   popupTasksTab: true,
   popupOverflowMode: "auto",
-  popupTasksRange: 365,
-  popupLaterTasks: "gray",
+  popupHideFutureTasks: false,
+  popupHideFutureTasksRange: 365,
   removeAttendance: "none",
   notifySurveySubjects: [],
   autoAdfs: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,9 +16,9 @@ export type Settings = {
   };
   popupBadge: boolean;
   popupTasksTab: boolean;
-  popupOverflowMode: "hidden" | "scroll";
+  popupOverflowMode: "hidden" | "auto";
   popupTasksRange: number;
-  popupLaterTasks: "normal" | "gray" | "collapse" | "hidden";
+  popupLaterTasks: "normal" | "gray" | "hidden";
   removeAttendance: "none" | "only" | "all";
   notifySurveySubjects: Subject[];
   autoAdfs: boolean;
@@ -103,7 +103,7 @@ export const defaultSettings: Settings = {
   },
   popupBadge: true,
   popupTasksTab: true,
-  popupOverflowMode: "scroll",
+  popupOverflowMode: "auto",
   popupTasksRange: 365,
   popupLaterTasks: "gray",
   removeAttendance: "none",


### PR DESCRIPTION
## 概要
Popup画面およびその機能の実装を行いました。

### 移植した機能
- 時間割の表示
  - 科目名、教室名の表示
  - 科目ページへの移動
- 課題の表示
  - 科目名、課題名、提出期限の表示
  - 数が多い場合の表示方法の切り替え
  - 取得日時の表示
  - 課題の手動更新
- フッター
- 設定 (一部設定内容を変更、Migrationで対応済み)

### 新規機能
- popup時間割において、サイドメニューと同様に土曜日に講義がない場合や5限以降に講義がない場合に自動で非表示にするように
- popup課題一覧において、あふれた課題を省略する設定にした場合、残り課題数をクリックすると一時的にスクロールに切り替えて全ての課題を確認できるように
- popup関連に設定を旧Utilitiesから移行できるように
- 全操作をキーボードのみで行えるように

### 既存機能の変更
- 未提出課題数のバッジ表示(popupBadge)を詳細設定からポップアップ設定に移動

## 関連Issue
#35 

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
### 時間割ビュー
![image](https://github.com/scombz-utilities/scombz-utilities-react/assets/61535180/1487b0fa-319d-4d05-8d2d-3e37296dcd12)

### 課題ビュー
省略表示
![image](https://github.com/scombz-utilities/scombz-utilities-react/assets/61535180/2c2d5cac-f468-4169-97d8-9c6f43fa6876)

スクロール表示
![image](https://github.com/scombz-utilities/scombz-utilities-react/assets/61535180/68c87b1a-1286-42fb-858a-9d69ae698166)

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
  - [x] 最新のChromeで確認をした
  - [x] 最新のFirefoxで確認をした
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- newfunc - 新機能追加

### タイトル

ポップアップ機能の実装

### 詳細

旧Utilitesからポップアップ機能を移植しました。また、時間割に表示する項目の自動最適化やポップアップ上の要素のキーボード操作など、使い勝手の改善も行いました。

## コメント
