### PR TITLE
fix: popupから課題一覧を取得するとtask.linkのoriginがおかしくなる

### DIFF
--- a/src/contents/util/getTaskList.ts
+++ b/src/contents/util/getTaskList.ts
@@ -17,11 +17,20 @@ const getTasks = (doc: Document): Task[] => {
       deadline: taskNode.querySelector(".tasklist-deadline .deadline").innerHTML,
       id: null,
     };
-    if (task.link.includes("idnumber=")) {
-      task.id = task.link.slice(task.link.indexOf("idnumber=") + 9).replace(/&|Id=/g, "");
-    }
-    if (!task.link.startsWith("https://scombz.shibaura-it.ac.jp")) {
-      task.link = "https://scombz.shibaura-it.ac.jp" + task.link;
+    const taskLinkObj = new URL(task.link);
+    if (taskLinkObj.origin !== "https://scombz.shibaura-it.ac.jp") {
+      switch (taskLinkObj.pathname) {
+        case "/lms/course/report/submission":
+        case "/lms/course/surveys/take":
+        case "/portal/surveys/take":
+        case "/lms/course/examination/take":
+          taskLinkObj.protocol = "https:";
+          taskLinkObj.hostname = "scombz.shibaura-it.ac.jp";
+          task.link = taskLinkObj.toString();
+          break;
+        default:
+          task.link = "";
+      }
     }
     taskList.push(task);
   }

--- a/src/contents/util/getTaskList.ts
+++ b/src/contents/util/getTaskList.ts
@@ -17,6 +17,9 @@ const getTasks = (doc: Document): Task[] => {
       deadline: taskNode.querySelector(".tasklist-deadline .deadline").innerHTML,
       id: null,
     };
+    if (task.link.includes("idnumber=")) {
+      task.id = task.link.slice(task.link.indexOf("idnumber=") + 9).replace(/&|Id=/g, "");
+    }
     const taskLinkObj = new URL(task.link);
     if (taskLinkObj.origin !== "https://scombz.shibaura-it.ac.jp") {
       switch (taskLinkObj.pathname) {


### PR DESCRIPTION
## 概要
- task取得時のoriginの判定方法および置換方法を変更
  - popupで課題を取得時originが拡張機能のものになってしまう問題を修正

## 関連Issue
#83 

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
  - [x] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル
popupから課題一覧を取得した場合のリンクが正しくない問題を修正

### 詳細
popupから課題一覧を取得した場合に、課題ページへのリンクが機能しなくなる問題を修正しました。

## コメント
