### PR TITLE
fix: popupから課題取得時、Firefoxの場合は代わりに課題一覧を開くように

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -517,6 +517,10 @@
     "message": "Intensive\ncourses",
     "description": "集中講義"
   },
+  "popupOpenTasksPage": {
+    "message": "Open assignments list",
+    "description": "課題一覧を開く"
+  },
   "basicOptions_ClickLoginButtonAutomatically": {
     "message": "Automatically click the login button",
     "description": "ログインボタンを自動クリック"

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -517,6 +517,10 @@
     "message": "その他",
     "description": "集中講義"
   },
+  "popupOpenTasksPage": {
+    "message": "課題一覧を開く",
+    "description": "課題一覧を開く"
+  },
   "basicOptions_ClickLoginButtonAutomatically": {
     "message": "ログインボタンを自動クリック",
     "description": "ログインボタンを自動クリック"

--- a/src/contents/tasks.ts
+++ b/src/contents/tasks.ts
@@ -16,6 +16,11 @@ if (location.href === "https://scombz.shibaura-it.ac.jp/lms/task") {
 
 // タスクを取得
 export const fetchTasks = async (forceExecute?: boolean) => {
+  // Firefoxかつpopupからの場合CORSの関係上動作しないので除外
+  if (process.env.PLASMO_BROWSER === "firefox" && !location.href.startsWith("https://scombz.shibaura-it.ac.jp/")) {
+    return;
+  }
+
   // TOPページを除外する
   if (location.href.startsWith("https://scombz.shibaura-it.ac.jp/login")) {
     return;

--- a/src/popup/components/TasksBottom.tsx
+++ b/src/popup/components/TasksBottom.tsx
@@ -43,8 +43,10 @@ export const TasksBottom = (props: TasksBottomProps) => {
 
     // FirefoxだとCORSの関係上popupからのfetchが使えないので代わりに課題一覧を開く
     if (process.env.PLASMO_BROWSER === "firefox") {
-      window.open("https://scombz.shibaura-it.ac.jp/lms/task", "_blank");
-      window.close();
+      const newWindow = window.open("https://scombz.shibaura-it.ac.jp/lms/task", "_blank");
+      if (newWindow) {
+        window.close();
+      }
       return;
     }
 

--- a/src/popup/components/TasksBottom.tsx
+++ b/src/popup/components/TasksBottom.tsx
@@ -41,6 +41,13 @@ export const TasksBottom = (props: TasksBottomProps) => {
       }
     };
 
+    // FirefoxだとCORSの関係上popupからのfetchが使えないので代わりに課題一覧を開く
+    if (process.env.PLASMO_BROWSER === "firefox") {
+      window.open("https://scombz.shibaura-it.ac.jp/lms/task", "_blank");
+      window.close();
+      return;
+    }
+
     if (isFetching) return;
     setIsFetching(true);
 
@@ -58,7 +65,13 @@ export const TasksBottom = (props: TasksBottomProps) => {
           </Tooltip>
         )}
       </Box>
-      <Tooltip title={chrome.i18n.getMessage("reloadTaskList")}>
+      <Tooltip
+        title={
+          process.env.PLASMO_BROWSER === "firefox"
+            ? chrome.i18n.getMessage("popupOpenTasksPage")
+            : chrome.i18n.getMessage("reloadTaskList")
+        }
+      >
         <Button variant="text" size="small" color="inherit" disabled={isFetching} onClick={handleRefresh}>
           {chrome.i18n.getMessage("taskListLastUpdate")}: {format(new Date(lastTaskFetchUnixTime), "yyyy/MM/dd HH:mm")}
         </Button>


### PR DESCRIPTION
### **User description**
## 概要
‐ Firefoxの場合、CORSの関係でpopupから課題のfetchが行えないので代わりに新規タブでScombZの課題一覧ページを開くように変更

## 関連Issue
#86 

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
  - [x] 最新のChromeで確認をした
  - [x] 最新のFirefoxで確認をした
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

Firefox使用時のpopup内課題一覧更新日時クリック時の挙動を変更

### 詳細

Firefox使用時のみ、popup内の課題一覧更新日時をクリックした際の挙動を新規タブでScombZの課題一覧ページを開くように変更しました。

## コメント


___

### **PR Type**
Bug fix


___

### **Description**
- FirefoxでのCORS問題を回避するため、popupから課題取得時に課題一覧ページを新規タブで開く処理を追加
- Firefoxの場合、特定のURLでのfetchを除外する条件を追加
- ツールチップのメッセージをFirefox用に変更
- 新しいメッセージキー`popupOpenTasksPage`を英語と日本語のロケールファイルに追加


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.ts</strong><dd><code>FirefoxでのCORS問題を回避する条件追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/contents/tasks.ts
- FirefoxでのCORS問題を回避するための条件追加
- Firefoxの場合、特定のURLでのfetchを除外



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/87/files#diff-62ec33dbee6eb72876495cd3bc23a94d1c9d0303df96b24a170acc18c2801e7f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TasksBottom.tsx</strong><dd><code>Firefox用の課題一覧ページを開く処理追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/popup/components/TasksBottom.tsx
<li>FirefoxでのCORS問題を回避するための条件追加<br> <li> Firefoxの場合、課題一覧ページを新規タブで開く処理追加<br> <li> ツールチップのメッセージをFirefox用に変更<br>


</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/87/files#diff-a11415c3123074da7619d9dd1add9f20f0c528a05df69dc23dc6b65d7ca273ef">+14/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messages.json</strong><dd><code>新しいメッセージキー追加（英語）</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

locales/en/messages.json
- 新しいメッセージキー`popupOpenTasksPage`を追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/87/files#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>messages.json</strong><dd><code>新しいメッセージキー追加（日本語）</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

locales/ja/messages.json
- 新しいメッセージキー`popupOpenTasksPage`を追加



</details>
    

  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/87/files#diff-26b2dd93f3970aeba3b6cd3511fc7a0bb496619eef236e517ae3277bf999b309">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

