### PR TITLE
カスタムCSSがダークモードCSSよりも優先されるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scombz-utilities",
   "displayName": "ScombZ Utilities",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "__MSG_extensionDescription__",
   "author": "udai",
   "scripts": {

--- a/src/contents/layout.ts
+++ b/src/contents/layout.ts
@@ -134,11 +134,11 @@ const layout = async () => {
   if (settings.layout.removePageTop) removePageTop();
   if (settings.layout.removeDirectLink) removeDirectLink();
   if (settings.layout.clickToHideName) clickToHideName();
-  if (settings.customCSS.length > 0) {
-    document.head.insertAdjacentHTML("beforeend", `<style>${settings.customCSS}</style>`);
-  }
   if (settings.darkMode) {
     document.body.insertAdjacentHTML("afterbegin", `<style>${darkModeCSS}</style>`);
+  }
+  if (settings.customCSS.length > 0) {
+    document.body.insertAdjacentHTML("beforeend", `<style>${settings.customCSS}</style>`);
   }
   fixHeadShadow();
   addExtensionSettingsBtn();


### PR DESCRIPTION
### **User description**
## 概要

- やること、やったことを書く

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [ ] NO

## チェック項目

- [ ] ビルドが通る
- [ ] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
  - [ ] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント


___

### **PR Type**
Enhancement


___

### **Description**
- カスタムCSSの挿入位置を変更し、ダークモードCSSよりも後に適用されるように修正しました。
- `document.head`から`document.body`への変更を行いました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.ts</strong><dd><code>カスタムCSSの適用順序をダークモードCSSの後に変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/contents/layout.ts

<li>カスタムCSSの挿入位置を変更し、ダークモードCSSよりも後に適用されるように修正<br> <li> <code>document.head</code>から<code>document.body</code>への変更<br>


</details>


  </td>
  <td><a href="https://github.com/scombz-utilities/scombz-utilities-react/pull/109/files#diff-e6ce0f65a20a725c0ac5a490040db356bc8e759749675ce1e00691440b7a5efd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

