### PR TITLE
2025年度入学に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scombz-utilities",
   "displayName": "ScombZ Utilities",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "__MSG_extensionDescription__",
   "author": "udai",
   "scripts": {

--- a/src/contents/sgsot.tsx
+++ b/src/contents/sgsot.tsx
@@ -76,12 +76,6 @@ const AcademicGuidesJa = () => {
           url: `https://shibaura-it.notion.site/13f80feff3d1804cb8cae22d3bafe5d5?v=13f80feff3d18187964a000c34d47d73`,
         });
       }
-      if (faculty === "d") {
-        newButtons.push({
-          name: `建築学部2025年度入学`,
-          url: `https://www.shibaura-it.ac.jp/extra/tebiki2025/architecture/index.html`,
-        });
-      }
       setButtons(newButtons);
       return;
     }
@@ -98,6 +92,12 @@ const AcademicGuidesJa = () => {
         newButtons.push({
           name: `システム理工学部20${year}年度入学`,
           url: `https://www.shibaura-it.ac.jp/extra/tebiki20${year}/systems/index.html`,
+        });
+      }
+      if (faculty === "d") {
+        newButtons.push({
+          name: `建築学部20${year}年度入学`,
+          url: `https://www.shibaura-it.ac.jp/extra/tebiki20${year}/architecture/index.html`,
         });
       }
     } else {

--- a/src/contents/sgsot.tsx
+++ b/src/contents/sgsot.tsx
@@ -68,33 +68,67 @@ const AcademicGuidesJa = () => {
 
     const newButtons: Buttons[] = [];
 
-    switch (faculty) {
-      case "a":
+    // 特殊事例の辞書対応
+    if (year === 25) {
+      if (faculty === "c") {
+        newButtons.push({
+          name: `デザイン工学部2025年度入学`,
+          url: `https://shibaura-it.notion.site/13f80feff3d1804cb8cae22d3bafe5d5?v=13f80feff3d18187964a000c34d47d73`,
+        });
+      }
+      if (faculty === "d") {
+        newButtons.push({
+          name: `建築学部2025年度入学`,
+          url: `https://www.shibaura-it.ac.jp/extra/tebiki2025/architecture/index.html`,
+        });
+      }
+      setButtons(newButtons);
+      return;
+    }
+
+    // 25年度からの手引きのURLが変わっている学部がある
+    if (year >= 25) {
+      if (faculty === "a") {
         newButtons.push({
           name: `工学部20${year}年度入学`,
-          url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/engineering/`,
+          url: `https://www.shibaura-it.ac.jp/extra/tebiki20${year}/engineering/index.html`,
         });
-        break;
-      case "b":
+      }
+      if (faculty === "b") {
         newButtons.push({
           name: `システム理工学部20${year}年度入学`,
-          url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/systems/`,
+          url: `https://www.shibaura-it.ac.jp/extra/tebiki20${year}/systems/index.html`,
         });
-        break;
-      case "c":
-        newButtons.push({
-          name: `デザイン工学部20${year}年度入学`,
-          url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/design/`,
-        });
-        break;
-      case "d":
-        newButtons.push({
-          name: `建築学部20${year}年度入学`,
-          url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/architecture/`,
-        });
-        break;
-      default:
-        break;
+      }
+    } else {
+      switch (faculty) {
+        case "a":
+          newButtons.push({
+            name: `工学部20${year}年度入学`,
+            url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/engineering/`,
+          });
+          break;
+        case "b":
+          newButtons.push({
+            name: `システム理工学部20${year}年度入学`,
+            url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/systems/`,
+          });
+          break;
+        case "c":
+          newButtons.push({
+            name: `デザイン工学部20${year}年度入学`,
+            url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/design/`,
+          });
+          break;
+        case "d":
+          newButtons.push({
+            name: `建築学部20${year}年度入学`,
+            url: `https://guide.shibaura-it.ac.jp/tebiki20${year}/architecture/`,
+          });
+          break;
+        default:
+          break;
+      }
     }
 
     setButtons(newButtons);

--- a/src/contents/tebikiRedirect.ts
+++ b/src/contents/tebikiRedirect.ts
@@ -1,0 +1,15 @@
+import type { PlasmoCSConfig } from "plasmo";
+
+export const config: PlasmoCSConfig = {
+  matches: ["https://guide.shibaura-it.ac.jp/*", "https://www.shibaura-it.ac.jp/extra/*"],
+  run_at: "document_end",
+};
+
+if (
+  document.title.includes("404") &&
+  document.title.toLowerCase().includes("not") &&
+  document.title.toLowerCase().includes("found") &&
+  location.href.includes("tebiki")
+) {
+  location.href = "https://www.shibaura-it.ac.jp/campus_life/class/class.html";
+}


### PR DESCRIPTION
## 概要

- 2025年度入学では全学部において学修の手引きのURL命名規則が変更されている。そのための対応を行なった。
  - デザイン工学部: Notionになったため辞書対応
  - 工学部、システム理工学部、建築学部: 25年度以降は命名規則を変更

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
  - [x] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/release/ に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント
