### PR TITLE
履修登録できない問題への緊急対応

### DIFF
--- a/src/contents/sgsot.tsx
+++ b/src/contents/sgsot.tsx
@@ -36,18 +36,26 @@ const inputUser = async () => {
 };
 
 const AcademicGuidesEn = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(true);
   return (
     <>
-      <Button
-        href="https://www.shibaura-it.ac.jp/en/campus_life/academic_life/academic_guide.html"
-        variant="contained"
-        target="_blank"
-      >
-        Open Academic Guides (English)
-      </Button>
-      <Button href="https://www.shibaura-it.ac.jp/campus_life/class/class.html" target="_blank" variant="text">
-        Open Academic Guides (Japanese)
-      </Button>
+      {isOpen && (
+        <>
+          <Button
+            href="https://www.shibaura-it.ac.jp/en/campus_life/academic_life/academic_guide.html"
+            variant="contained"
+            target="_blank"
+          >
+            Open Academic Guides (English)
+          </Button>
+          <Button href="https://www.shibaura-it.ac.jp/campus_life/class/class.html" target="_blank" variant="text">
+            Open Academic Guides (Japanese)
+          </Button>
+          <Button variant="text" onClick={() => setIsOpen(!isOpen)}>
+            Close
+          </Button>
+        </>
+      )}
     </>
   );
 };
@@ -153,6 +161,7 @@ const Sgsot = () => {
     () => location.href.match(/^https?:\/\/sgsot[0-9]+[a-z]+\.sic\.shibaura-it\.ac\.jp\/[A-z]{2}[0-9]{5}\/?$/),
     [],
   );
+  const [isOpen, setIsOpen] = useState<boolean>(true);
 
   useEffect(() => {
     const subDomain = location.origin.split(".")[0].split("//")[1];
@@ -165,9 +174,14 @@ const Sgsot = () => {
     <CacheProvider value={styleCache}>
       <ThemeProvider theme={theme}>
         <Stack position={"fixed"} bottom={20} right={20}>
-          <ButtonGroup orientation="vertical" aria-label="Open Academic Guide" size="small">
-            {chrome.i18n.getUILanguage() === "ja" ? <AcademicGuidesJa /> : <AcademicGuidesEn />}
-          </ButtonGroup>
+          {isOpen && (
+            <ButtonGroup orientation="vertical" aria-label="Open Academic Guide" size="small">
+              {chrome.i18n.getUILanguage() === "ja" ? <AcademicGuidesJa /> : <AcademicGuidesEn />}
+              <Button variant="text" onClick={() => setIsOpen(!isOpen)}>
+                Close
+              </Button>
+            </ButtonGroup>
+          )}
         </Stack>
       </ThemeProvider>
     </CacheProvider>


### PR DESCRIPTION
## 概要

- S*gsotの履修申請ページで「学習の手引きを開く」ボタンが右下に配置されており、もとからある「続ける」ボタンに干渉してクリックできない問題への対処

## 関連Issue

142 （根本的には治ってないのでリンクしません）

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [ ] NO

## チェック項目

- [ ] ビルドが通る
- [ ] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
  - [ ] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/release/ に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント
