### PR TITLE
innerHTMLにすべきでない部分を全てinnerTextに変更

### DIFF
--- a/src/contents/examPageLayout.ts
+++ b/src/contents/examPageLayout.ts
@@ -11,10 +11,7 @@ export const config: PlasmoCSConfig = {
 const styleExam = () => {
   if (location.href.startsWith("https://scombz.shibaura-it.ac.jp/lms/course/examination/take")) {
     //テストを受ける前の画面
-    if (
-      document.querySelector(".block-under-area-btn") &&
-      document.querySelector(".block-under-area-btn").innerHTML.includes("受験する")
-    ) {
+    if ((document.querySelector(".block-under-area-btn") as HTMLDivElement)?.innerText.includes("受験する")) {
       document.head.insertAdjacentHTML(
         "beforeend",
         `
@@ -69,10 +66,7 @@ const styleExam = () => {
       if (document.querySelector(".page-directlink")) document.querySelector(".page-directlink").remove();
     }
     //テスト中の画面
-    if (
-      document.querySelector(".block-under-area-btn") &&
-      document.querySelector(".block-under-area-btn").innerHTML.includes("一時保存する")
-    ) {
+    if ((document.querySelector(".block-under-area-btn") as HTMLDivElement)?.innerText.includes("一時保存する")) {
       const $examTimer = document.getElementById("examTimer");
       window.onbeforeunload = function (e) {
         if (

--- a/src/contents/oldScomb.ts
+++ b/src/contents/oldScomb.ts
@@ -5,9 +5,9 @@ export const config: PlasmoCSConfig = {
   run_at: "document_end",
 };
 
-const scombLoginBtns = document.querySelectorAll("strong");
+const scombLoginBtns = document.querySelectorAll("strong") as NodeListOf<HTMLElement>;
 for (const scombLoginBtn of scombLoginBtns) {
-  if (scombLoginBtn.innerHTML.includes("ScombZ")) {
+  if (scombLoginBtn.innerText.includes("ScombZ")) {
     (scombLoginBtn.parentNode.parentNode.parentNode as HTMLElement).insertAdjacentHTML(
       "afterbegin",
       `

--- a/src/contents/redirectTempFile.ts
+++ b/src/contents/redirectTempFile.ts
@@ -6,7 +6,7 @@ export const config: PlasmoCSConfig = {
   run_at: "document_end",
 };
 
-const fileId = document.body.innerHTML;
+const fileId = document.body.innerText;
 const url = new URL(location.href);
 const params = url.searchParams;
 

--- a/src/contents/util/getLMS.ts
+++ b/src/contents/util/getLMS.ts
@@ -19,7 +19,7 @@ export const getLMS = (d: Document): TimeTable => {
     return [];
   }
   // データ取得
-  const $courseList = d.querySelectorAll(".timetable-course-top-btn");
+  const $courseList = d.querySelectorAll(".timetable-course-top-btn") as NodeListOf<HTMLElement>;
   if ($courseList[0]) {
     //JSON生成
     const $timetableData = [];
@@ -32,14 +32,13 @@ export const getLMS = (d: Document): TimeTable => {
       };
       for (let $yobicolNum = 1; $yobicolNum < 7; $yobicolNum++) {
         if (($course.parentNode.parentNode as HTMLElement).className.indexOf($yobicolNum + "-yobicol") != -1) {
-          ($timetableClassData.day = $yobicolNum),
-            ($timetableClassData.time = Number(
-              jigenInt($course.parentNode.parentNode.parentNode.firstElementChild.innerHTML),
-            ));
+          const jigenNode = $course.parentNode.parentNode.parentNode.firstElementChild as HTMLElement;
+
+          $timetableClassData.day = $yobicolNum;
+          $timetableClassData.time = Number(jigenInt(jigenNode.innerText));
+
           if (!$timetableClassData.time) {
-            $timetableClassData.time = Number(
-              $course.parentNode.parentNode.parentNode.firstElementChild.innerHTML.slice(-1),
-            );
+            $timetableClassData.time = Number(jigenNode.innerText.slice(-1));
           }
           break;
         }
@@ -52,7 +51,7 @@ export const getLMS = (d: Document): TimeTable => {
         continue;
       }
       $timetableClassData.id = $course.getAttribute("id");
-      $timetableClassData.name = $course.innerHTML;
+      $timetableClassData.name = $course.innerText;
       $timetableClassData.classroom = $course.nextElementSibling?.firstElementChild?.getAttribute("title") ?? "";
       const $courseTeacherList =
         $course.nextElementSibling?.querySelectorAll("div[data-toggle='tooltip'] > span") || [];

--- a/src/contents/util/getTaskList.ts
+++ b/src/contents/util/getTaskList.ts
@@ -11,10 +11,10 @@ const getTasks = (doc: Document): Task[] => {
   for (const taskNode of taskNodeList) {
     const task: Task = {
       kind: "task",
-      course: taskNode.querySelector(".course").innerHTML,
-      title: taskNode.querySelector(".tasklist-title a:nth-child(1)").innerHTML,
+      course: (taskNode.querySelector(".course") as HTMLElement).innerText,
+      title: (taskNode.querySelector(".tasklist-title a:nth-child(1)") as HTMLElement).innerText,
       link: (taskNode.querySelector(".tasklist-title a:nth-child(1)") as HTMLAnchorElement).href,
-      deadline: taskNode.querySelector(".tasklist-deadline .deadline").innerHTML,
+      deadline: (taskNode.querySelector(".tasklist-deadline .deadline") as HTMLElement).innerText,
       id: null,
     };
     if (task.link.includes("idnumber=")) {
@@ -88,7 +88,7 @@ export const fetchSurveys = async () => {
   while (doc.querySelector(`#portalSurveysForm .result-list:nth-of-type(${i + 1})`)) {
     const titleElement = doc.querySelector(
       `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-title .template-name`,
-    );
+    ) as HTMLElement;
     const endColorElement = doc.querySelector(
       `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-title .portal-surveys-status-end-color`,
     );
@@ -109,16 +109,22 @@ export const fetchSurveys = async () => {
       deadline: "",
       id: "",
     };
-    taskObj.title = titleElement.innerHTML;
-    taskObj.course = doc.querySelector(
-      `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-address span`,
-    ).innerHTML;
-    taskObj.startline = doc.querySelector(
-      `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-update span:nth-of-type(1)`,
-    ).innerHTML;
-    taskObj.deadline = doc.querySelector(
-      `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-update span:nth-of-type(3)`,
-    ).innerHTML;
+    taskObj.title = titleElement.innerText;
+    taskObj.course = (
+      doc.querySelector(
+        `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-address span`,
+      ) as HTMLElement
+    ).innerText;
+    taskObj.startline = (
+      doc.querySelector(
+        `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-update span:nth-of-type(1)`,
+      ) as HTMLElement
+    ).innerText;
+    taskObj.deadline = (
+      doc.querySelector(
+        `#portalSurveysForm .result-list:nth-of-type(${i + 1}) .survey-list-update span:nth-of-type(3)`,
+      ) as HTMLElement
+    ).innerText;
     taskObj.id = (
       doc.querySelector(`#portalSurveysForm .result-list:nth-of-type(${i + 1}) #listSurveyId`) as HTMLInputElement
     ).value;


### PR DESCRIPTION
## 概要

- innerHTMLを使用すべきでない、要素内のテキストを取り出す処理（右辺値として使用している処理）を全てinnerTextに変更しました
- HTML要素を直接代入するinnerHTML（左辺値として使用している処理）には変更を加えていません
- これにより、一部の文字がエンコードされた状態で取得されるバグ（#145 ）が修正されます
- 卒業により正しく動くか調査不可能なため、動作確認とレビューをお願いします

## 関連Issue

#145 

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
  - [ ] 最新のChromeで確認をした
  - [ ] 最新のFirefoxで確認をした
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

### タイトル

一部の授業や課題の名前が正しく取得されない問題の修正

### 詳細

&などが含まれる、一部の授業や課題の名前が正しく取得されない問題を修正しました。

## コメント
