### PR TITLE
github actionがubuntu20.04をサポートしなくなったのでアップデート

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   eslint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: ESLint
         run: npm run eslint
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## 概要

- github actionがubuntu20.04をサポートしなくなったので、24.04にアップデート
